### PR TITLE
feat: direct-patch fast path — skip per-change view recompute (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/SemVer
 
 ## [Unreleased]
 
+### Added
+
+- **Direct-patch fast path (#56)**: an eligible row-level `UPDATE` whose changed
+  columns all map identity-style to top-level `data` keys now patches
+  `tv_<entity>` (and nested-object parents) directly via `jsonb_smart_patch_*`,
+  skipping the backing-view recompute entirely (zero view queries, counter-proven).
+  Anything outside the eligibility boundary falls back to the recompute path, which
+  remains the source of truth; the fast-path `data` output is byte-identical to a
+  recompute. New GUC `pg_tviews.direct_patch_enabled` (bool, default `on`) is a
+  kill-switch. New `pg_tviews_queue_stats()` counters: `direct_patch_captured`,
+  `direct_patches_applied`, `direct_patch_fallbacks`, `view_recomputes`.
+  `pg_tview_meta` gains `direct_map_columns` / `direct_map_keys`.
+  **Upgrade note:** the column→key map is extracted at `pg_tviews_create` time, so
+  tviews created before this version have an empty map and stay on the recompute
+  path until re-created (`pg_tviews_drop` + `pg_tviews_create`).
+
 ## [0.1.0-beta.13] - 2026-07-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -232,6 +232,62 @@ JOIN tb_user u ON p.fk_user = u.pk_user;
 
 ---
 
+## ⚡ Direct-patch fast path (Issue #56)
+
+For an eligible `UPDATE`, pg_tviews builds a JSONB patch **at trigger time from
+`NEW`** and applies it straight to `tv_<entity>.data` with
+`jsonb_smart_patch_scalar/_nested` — **skipping the backing-view recompute
+entirely** (zero `SELECT … FROM v_entity`). The same patch is *derived* for
+parent tviews that embed the entity as a nested object, so a single-field change
+with a wide fan-out (e.g. an author edited on 60 posts) propagates as a handful of
+grouped patch UPDATEs with no view queries.
+
+Anything outside the eligibility boundary silently falls back to the normal
+recompute path, which stays the single source of truth — the fast path is a pure
+optimization and its `data` output is byte-identical to a recompute.
+
+### What qualifies
+
+The fast path engages only when **every** condition holds (otherwise recompute):
+
+- the change is a row-level `UPDATE` (INSERT/DELETE change membership);
+- `jsonb_delta` is installed and `pg_tviews.direct_patch_enabled = on`;
+- the entity is not `DISTINCT ON` and not a `UNION`;
+- every changed column maps identity-style to a top-level `data` key
+  (`jsonb_build_object('bio', bio)` — no expression, cast, or other relation);
+- no changed column is a foreign key, the primary key, or a column the tview also
+  projects **outside** `data`;
+- the changed values' types are TEXT/VARCHAR, INT2/4/8, BOOL, UUID, JSONB, or NULL
+  (anything else — float, numeric, timestamps, arrays — falls back);
+- for a parent, its dependency on the child is `nested_object` with a path
+  (array/scalar/UUID-fk parents recompute).
+
+### Kill-switch and observability
+
+```sql
+SET pg_tviews.direct_patch_enabled = off;   -- force the recompute path everywhere
+```
+
+`pg_tviews_queue_stats()` exposes the counters (session-cumulative):
+
+```sql
+SELECT pg_tviews_queue_stats();
+-- { … "direct_patch_captured": N, "direct_patches_applied": N,
+--     "direct_patch_fallbacks": N, "view_recomputes": N }
+```
+
+An eligible update leaves `view_recomputes` unchanged and bumps
+`direct_patches_applied` — proof it skipped the view.
+
+### Upgrade note
+
+The column→key map is extracted **at `pg_tviews_create` time**. Tviews created
+before this version have an empty map, so the fast path stays inactive for them
+until they are re-created (`pg_tviews_drop` + `pg_tviews_create`). Existing tviews
+keep working unchanged on the recompute path.
+
+---
+
 ## 🚀 UNLOGGED Tables
 
 **pg_tviews** automatically creates TVIEWs as **UNLOGGED tables** for maximum write performance.

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -86,6 +86,20 @@ pub struct TviewMeta {
     /// `distinct_on_keys` when the key is not aliased. Aligned by index.
     pub distinct_on_output_keys: Vec<String>,
 
+    /// Direct-patch column map (issue #56): base-table columns that map
+    /// identity-style to top-level keys of this entity's own `data` object.
+    ///
+    /// Aligned with [`Self::direct_map_keys`]: `direct_map_columns[i]` is a base
+    /// column name (e.g. `bio`) and `direct_map_keys[i]` the JSONB key it feeds
+    /// (e.g. `bio`). Populated at CREATE time from bare `jsonb_build_object` pairs;
+    /// empty ⇒ the direct-patch fast path never engages for this entity.
+    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
+    pub direct_map_columns: Vec<String>,
+
+    /// JSONB keys aligned with [`Self::direct_map_columns`]. See that field.
+    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
+    pub direct_map_keys: Vec<String>,
+
     /// `true` when this TVIEW's backing view is a `UNION ALL` or `UNION` query.
     ///
     /// Used to apply the duplicate-row policy when multiple rows are returned
@@ -99,6 +113,16 @@ pub struct TviewMeta {
     /// enabling indirect dependency tracking for multi-level cascades.
     pub cascade_paths: Vec<CascadePath>,
 }
+
+/// Shared SELECT column list + FROM used by every `TviewMeta` loader. Callers
+/// append their own `WHERE` / `ORDER BY`. One copy keeps the loaders from drifting
+/// out of sync as catalog columns are added (e.g. issue #56's direct-patch map).
+const META_SELECT: &str = "SELECT table_oid AS tview_oid, view_oid, entity, \
+     fk_columns, uuid_fk_columns, \
+     dependency_types, dependency_paths, array_match_keys, \
+     distinct_on_keys, distinct_on_output_keys, \
+     direct_map_columns, direct_map_keys, is_union, cascade_paths \
+     FROM pg_tview_meta";
 
 impl TviewMeta {
     /// Helper: Parse TEXT[] to Vec<DependencyType>
@@ -133,12 +157,7 @@ impl TviewMeta {
                 DatumWithOid::new(source_oid, PgOid::BuiltIn(PgBuiltInOids::OIDOID).value())
             }];
             let mut rows = client.select(
-                "SELECT table_oid AS tview_oid, view_oid, entity, \
-                        fk_columns, uuid_fk_columns, \
-                        dependency_types, dependency_paths, array_match_keys, \
-                        distinct_on_keys, distinct_on_output_keys, is_union, cascade_paths \
-                 FROM pg_tview_meta \
-                 WHERE view_oid = $1 OR table_oid = $1",
+                &format!("{META_SELECT} WHERE view_oid = $1 OR table_oid = $1"),
                 None,
                 &args,
             )?;
@@ -158,16 +177,8 @@ impl TviewMeta {
             let args = vec![unsafe {
                 DatumWithOid::new(entity_name, PgOid::BuiltIn(PgBuiltInOids::TEXTOID).value())
             }];
-            let mut rows = client.select(
-                "SELECT table_oid AS tview_oid, view_oid, entity, \
-                        fk_columns, uuid_fk_columns, \
-                        dependency_types, dependency_paths, array_match_keys, \
-                        distinct_on_keys, distinct_on_output_keys, is_union, cascade_paths \
-                 FROM pg_tview_meta \
-                 WHERE entity = $1",
-                None,
-                &args,
-            )?;
+            let mut rows =
+                client.select(&format!("{META_SELECT} WHERE entity = $1"), None, &args)?;
 
             match rows.next() {
                 Some(row) => Ok(Some(Self::from_spi_row(&row)?)),
@@ -179,16 +190,7 @@ impl TviewMeta {
     /// Load all TVIEW metadata
     pub fn load_all() -> spi::Result<Vec<Self>> {
         Spi::connect(|client| {
-            let rows = client.select(
-                "SELECT table_oid AS tview_oid, view_oid, entity, \
-                        fk_columns, uuid_fk_columns, \
-                        dependency_types, dependency_paths, array_match_keys, \
-                        distinct_on_keys, distinct_on_output_keys, is_union, cascade_paths \
-                 FROM pg_tview_meta \
-                 ORDER BY entity",
-                None,
-                &[],
-            )?;
+            let rows = client.select(&format!("{META_SELECT} ORDER BY entity"), None, &[])?;
 
             let mut result = Vec::new();
             for row in rows {
@@ -231,16 +233,8 @@ impl TviewMeta {
             let args = vec![unsafe {
                 DatumWithOid::new(tview_oid, PgOid::BuiltIn(PgBuiltInOids::OIDOID).value())
             }];
-            let mut rows = client.select(
-                "SELECT table_oid AS tview_oid, view_oid, entity, \
-                        fk_columns, uuid_fk_columns, \
-                        dependency_types, dependency_paths, array_match_keys, \
-                        distinct_on_keys, distinct_on_output_keys, is_union, cascade_paths \
-                 FROM pg_tview_meta \
-                 WHERE table_oid = $1",
-                None,
-                &args,
-            )?;
+            let mut rows =
+                client.select(&format!("{META_SELECT} WHERE table_oid = $1"), None, &args)?;
 
             let result = if let Some(row) = rows.next() {
                 Some(Self::from_spi_row(&row)?)
@@ -277,6 +271,15 @@ impl TviewMeta {
 
         // distinct_on_output_keys (TEXT[]) — projected OUTPUT column used by refresh/PK
         let distinct_on_output_keys: Vec<String> = row["distinct_on_output_keys"]
+            .value::<Vec<String>>()?
+            .unwrap_or_default();
+
+        // direct_map_columns / direct_map_keys (TEXT[]) — aligned column→key map
+        // for the issue #56 direct-patch fast path. Empty for pre-#56 tviews.
+        let direct_map_columns: Vec<String> = row["direct_map_columns"]
+            .value::<Vec<String>>()?
+            .unwrap_or_default();
+        let direct_map_keys: Vec<String> = row["direct_map_keys"]
             .value::<Vec<String>>()?
             .unwrap_or_default();
 
@@ -322,6 +325,8 @@ impl TviewMeta {
             array_match_keys: array_keys.unwrap_or_default(),
             distinct_on_keys,
             distinct_on_output_keys,
+            direct_map_columns,
+            direct_map_keys,
             is_union,
             cascade_paths,
         })
@@ -383,6 +388,22 @@ impl TviewMeta {
 
         details
     }
+
+    /// Build the direct-patch column→key lookup (issue #56): base-table column
+    /// name → JSONB key it feeds in this entity's own `data` object.
+    ///
+    /// Returns an empty map for entities without an extracted map (pre-#56 tviews,
+    /// or tviews whose `data` column isn't a bare `jsonb_build_object` of base
+    /// columns) — in which case the direct-patch fast path never engages.
+    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
+    #[must_use]
+    pub fn direct_map(&self) -> std::collections::HashMap<&str, &str> {
+        self.direct_map_columns
+            .iter()
+            .zip(self.direct_map_keys.iter())
+            .map(|(col, key)| (col.as_str(), key.as_str()))
+            .collect()
+    }
 }
 
 /// Represents a single dependency with its type, path, and match key.
@@ -411,6 +432,8 @@ impl Default for TviewMeta {
             array_match_keys: vec![],
             distinct_on_keys: vec![],
             distinct_on_output_keys: vec![],
+            direct_map_columns: vec![],
+            direct_map_keys: vec![],
             is_union: false,
             cascade_paths: vec![],
         }
@@ -527,6 +550,8 @@ mod tests {
             array_match_keys: vec![None],
             distinct_on_keys: vec![],
             distinct_on_output_keys: vec![],
+            direct_map_columns: vec!["bio".to_string(), "name".to_string()],
+            direct_map_keys: vec!["bio".to_string(), "display_name".to_string()],
             is_union: false,
             cascade_paths: vec![],
         };
@@ -534,6 +559,12 @@ mod tests {
         assert_eq!(meta.dependency_types.len(), 1);
         assert_eq!(meta.dependency_paths.len(), 1);
         assert_eq!(meta.array_match_keys.len(), 1);
+
+        // Direct-patch column map round-trips into a col→key lookup (issue #56).
+        let map = meta.direct_map();
+        assert_eq!(map.get("bio"), Some(&"bio"));
+        assert_eq!(map.get("name"), Some(&"display_name"));
+        assert_eq!(map.len(), 2);
     }
 
     #[test]

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -93,11 +93,9 @@ pub struct TviewMeta {
     /// column name (e.g. `bio`) and `direct_map_keys[i]` the JSONB key it feeds
     /// (e.g. `bio`). Populated at CREATE time from bare `jsonb_build_object` pairs;
     /// empty ⇒ the direct-patch fast path never engages for this entity.
-    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
     pub direct_map_columns: Vec<String>,
 
     /// JSONB keys aligned with [`Self::direct_map_columns`]. See that field.
-    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
     pub direct_map_keys: Vec<String>,
 
     /// `true` when this TVIEW's backing view is a `UNION ALL` or `UNION` query.
@@ -395,7 +393,7 @@ impl TviewMeta {
     /// Returns an empty map for entities without an extracted map (pre-#56 tviews,
     /// or tviews whose `data` column isn't a bare `jsonb_build_object` of base
     /// columns) — in which case the direct-patch fast path never engages.
-    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
+    #[allow(dead_code)] // Reason: public helper; the trigger reads the map off the cached EntityInfo
     #[must_use]
     pub fn direct_map(&self) -> std::collections::HashMap<&str, &str> {
         self.direct_map_columns

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,6 +19,7 @@
 //! | `pg_tviews.max_dependency_depth` | int | 10 | Max `pg_depend` traversal depth |
 //! | `pg_tviews.batch_size` | int | 1000 | Max PKs per bulk-refresh statement |
 //! | `pg_tviews.cache_size` | int | 10000 | Max entries per in-memory cache |
+//! | `pg_tviews.direct_patch_enabled` | bool | true | Direct-patch fast path (issue #56) |
 //!
 //! ## Compile-time Constants
 //!
@@ -52,6 +53,7 @@ static SUSPEND_TRIGGERS_GUC: GucSetting<bool> = GucSetting::<bool>::new(false);
 static MAX_DEPENDENCY_DEPTH_GUC: GucSetting<i32> = GucSetting::<i32>::new(10);
 static BATCH_SIZE_GUC: GucSetting<i32> = GucSetting::<i32>::new(1_000);
 static CACHE_SIZE_GUC: GucSetting<i32> = GucSetting::<i32>::new(10_000);
+static DIRECT_PATCH_ENABLED_GUC: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 // ── GUC registration (called from _PG_init) ─────────────────────────────
 
@@ -188,6 +190,18 @@ pub fn register_gucs() {
         GucContext::Userset,
         GucFlags::default(),
     );
+
+    GucRegistry::define_bool_guc(
+        c"pg_tviews.direct_patch_enabled",
+        c"Enable the direct-patch fast path for eligible single-row UPDATEs.",
+        c"When true (default), an UPDATE whose changed columns all map identity-style \
+          to JSONB keys patches tv_<entity> directly, skipping the backing-view \
+          recompute. When false, every change takes the recompute path. Purely a \
+          performance switch — results are identical either way (issue #56).",
+        &DIRECT_PATCH_ENABLED_GUC,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }
 
 // ── Public accessors (same signatures as the old const fns) ──────────────
@@ -282,4 +296,14 @@ pub fn batch_size() -> usize {
 #[must_use]
 pub fn cache_size() -> usize {
     CACHE_SIZE_GUC.get().unsigned_abs().max(1) as usize
+}
+
+/// Check if the direct-patch fast path is enabled (default: true, issue #56).
+///
+/// Checked at capture time (trigger) and apply time (flush); when false the
+/// recompute path is used exclusively. A pure performance switch — the resulting
+/// `tv_<entity>.data` is byte-identical either way.
+#[must_use]
+pub fn direct_patch_enabled() -> bool {
+    DIRECT_PATCH_ENABLED_GUC.get()
 }

--- a/src/ddl/create.rs
+++ b/src/ddl/create.rs
@@ -1,6 +1,9 @@
 use crate::cascade_path;
 use crate::error::{TViewError, TViewResult};
-use crate::schema::{TViewSchema, analyzer::analyze_dependencies, inference::infer_schema};
+use crate::schema::{
+    TViewSchema, analyzer::analyze_dependencies, direct_map::extract_direct_column_map,
+    inference::infer_schema,
+};
 use crate::utils::quote_identifier;
 use pgrx::datum::DatumWithOid;
 use pgrx::pg_sys::Oid;
@@ -1113,6 +1116,21 @@ fn register_metadata(
     // Analyze dependencies to populate type/path/match_key info
     let dep_infos = analyze_dependencies(definition_sql, &schema.fk_columns);
 
+    // Extract the direct-patch column→key map (issue #56): base columns that map
+    // identity-style to top-level keys of this entity's own `data` object. Empty
+    // ⇒ the direct-patch fast path never engages for this entity.
+    let direct_map = extract_direct_column_map(definition_sql, &format!("tb_{entity_name}"));
+    let direct_map_columns = direct_map
+        .iter()
+        .map(|(col, _)| pg_array_elem(col))
+        .collect::<Vec<_>>()
+        .join(",");
+    let direct_map_keys = direct_map
+        .iter()
+        .map(|(_, key)| pg_array_elem(key))
+        .collect::<Vec<_>>()
+        .join(",");
+
     // Serialize schema information (quoted for safe PostgreSQL array literals)
     let fk_columns = schema
         .fk_columns
@@ -1233,8 +1251,10 @@ fn register_metadata(
             array_match_keys,
             distinct_on_keys,
             distinct_on_output_keys,
+            direct_map_columns,
+            direct_map_keys,
             is_union
-        ) VALUES ($1, {}, {}, $2, {}, '{{{}}}', '{{{}}}', '{{{}}}', '{{{}}}', '{{{}}}', '{{{}}}', '{{{}}}', {})
+        ) VALUES ($1, {}, {}, $2, {}, '{{{}}}', '{{{}}}', '{{{}}}', '{{{}}}', '{{{}}}', '{{{}}}', '{{{}}}', '{{{}}}', '{{{}}}', {})
         ON CONFLICT (entity) DO NOTHING",
         view_oid.to_u32(),
         table_oid.to_u32(),
@@ -1246,6 +1266,8 @@ fn register_metadata(
         array_keys,
         distinct_on_str,
         distinct_on_output_str,
+        direct_map_columns,
+        direct_map_keys,
         is_union
     );
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -138,7 +138,8 @@ fn pg_tviews_queue_stats() -> pgrx::JsonB {
         "graph_cache_hits": stats.graph_cache_hits,
         "graph_cache_misses": stats.graph_cache_misses,
         "table_cache_hits": stats.table_cache_hits,
-        "table_cache_misses": stats.table_cache_misses
+        "table_cache_misses": stats.table_cache_misses,
+        "direct_patch_captured": stats.direct_patch_captured
     });
 
     pgrx::JsonB(json_value)

--- a/src/health.rs
+++ b/src/health.rs
@@ -139,7 +139,10 @@ fn pg_tviews_queue_stats() -> pgrx::JsonB {
         "graph_cache_misses": stats.graph_cache_misses,
         "table_cache_hits": stats.table_cache_hits,
         "table_cache_misses": stats.table_cache_misses,
-        "direct_patch_captured": stats.direct_patch_captured
+        "direct_patch_captured": stats.direct_patch_captured,
+        "direct_patches_applied": stats.direct_patches_applied,
+        "direct_patch_fallbacks": stats.direct_patch_fallbacks,
+        "view_recomputes": stats.view_recomputes
     });
 
     pgrx::JsonB(json_value)

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -47,9 +47,20 @@ extension_sql!(
         array_match_keys TEXT[] NOT NULL DEFAULT '{}',
         distinct_on_keys TEXT[] NOT NULL DEFAULT '{}',
         distinct_on_output_keys TEXT[] NOT NULL DEFAULT '{}',
+        direct_map_columns TEXT[] NOT NULL DEFAULT '{}',
+        direct_map_keys TEXT[] NOT NULL DEFAULT '{}',
         is_union BOOLEAN NOT NULL DEFAULT FALSE,
         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     );
+
+    -- Upgrade path (issue #56): CREATE TABLE IF NOT EXISTS is a no-op on a
+    -- pre-existing catalog, so add the direct-patch column map idempotently.
+    -- Pre-existing tviews get empty maps ⇒ the fast path stays disabled for them
+    -- until they are re-created (documented behaviour, safe default).
+    ALTER TABLE @extschema@.pg_tview_meta
+        ADD COLUMN IF NOT EXISTS direct_map_columns TEXT[] NOT NULL DEFAULT '{}';
+    ALTER TABLE @extschema@.pg_tview_meta
+        ADD COLUMN IF NOT EXISTS direct_map_keys TEXT[] NOT NULL DEFAULT '{}';
 
     CREATE TABLE IF NOT EXISTS @extschema@.pg_tview_helpers (
         helper_name TEXT NOT NULL PRIMARY KEY,
@@ -266,6 +277,8 @@ pub fn create_metadata_tables() -> TViewResult<()> {
             dependency_paths TEXT[]  NOT NULL DEFAULT '{}',
             array_match_keys TEXT[] NOT NULL DEFAULT '{}',
             distinct_on_keys TEXT[] NOT NULL DEFAULT '{}',
+            direct_map_columns TEXT[] NOT NULL DEFAULT '{}',
+            direct_map_keys TEXT[] NOT NULL DEFAULT '{}',
             is_union BOOLEAN NOT NULL DEFAULT FALSE,
             created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
         );

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -26,6 +26,28 @@ use crate::queue::key::RefreshKey;
 // Thread-local storage to avoid contention between transactions
 thread_local! {
     static METRICS: std::cell::RefCell<QueueMetrics> = const { std::cell::RefCell::new(QueueMetrics::new_const()) };
+
+    /// Session-cumulative direct-patch counters (issue #56).
+    ///
+    /// Unlike `METRICS`, these are **not** reset at transaction boundaries, so a
+    /// counter set by a trigger during an auto-commit statement is still readable
+    /// via `pg_tviews_queue_stats()` in a following statement. Tests assert on the
+    /// delta across a mutation.
+    static DIRECT_PATCH_METRICS: std::cell::RefCell<DirectPatchMetrics> =
+        const { std::cell::RefCell::new(DirectPatchMetrics::new_const()) };
+}
+
+/// Session-cumulative counters for the direct-patch fast path (issue #56).
+#[derive(Debug, Default, Clone, Copy)]
+struct DirectPatchMetrics {
+    /// Eligible UPDATEs whose patch was captured by the row trigger.
+    captured: u64,
+}
+
+impl DirectPatchMetrics {
+    const fn new_const() -> Self {
+        Self { captured: 0 }
+    }
 }
 
 /// Structure holding current transaction metrics
@@ -165,10 +187,19 @@ pub mod metrics_api {
         });
     }
 
+    /// Record an eligible direct-patch capture (issue #56). Session-cumulative.
+    pub fn record_direct_patch_captured() {
+        DIRECT_PATCH_METRICS.with(|m| {
+            m.borrow_mut().captured += 1;
+        });
+    }
+
     /// Get current queue statistics
     pub fn get_queue_stats() -> QueueStats {
         // Get current queue size from state
         let queue_size = crate::queue::get_queue_size();
+
+        let direct_patch_captured = DIRECT_PATCH_METRICS.with(|m| m.borrow().captured);
 
         METRICS.with(|m| {
             let metrics = m.borrow();
@@ -186,6 +217,7 @@ pub mod metrics_api {
                 prepared_stmt_cache_misses: metrics.prepared_stmt_cache_misses,
                 bulk_refresh_count: metrics.bulk_refresh_count,
                 individual_refresh_count: metrics.individual_refresh_count,
+                direct_patch_captured,
             }
         })
     }
@@ -237,6 +269,8 @@ pub struct QueueStats {
     pub prepared_stmt_cache_misses: u64,
     pub bulk_refresh_count: u64,
     pub individual_refresh_count: u64,
+    /// Session-cumulative count of captured direct patches (issue #56).
+    pub direct_patch_captured: u64,
 }
 
 impl QueueStats {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -42,11 +42,22 @@ thread_local! {
 struct DirectPatchMetrics {
     /// Eligible UPDATEs whose patch was captured by the row trigger.
     captured: u64,
+    /// Tview rows updated directly by a patch (no backing-view query).
+    applied: u64,
+    /// Patched pks that fell back to recompute (row not yet materialised).
+    fallbacks: u64,
+    /// Tview rows recomputed from the backing view (the non-fast path).
+    view_recomputes: u64,
 }
 
 impl DirectPatchMetrics {
     const fn new_const() -> Self {
-        Self { captured: 0 }
+        Self {
+            captured: 0,
+            applied: 0,
+            fallbacks: 0,
+            view_recomputes: 0,
+        }
     }
 }
 
@@ -194,12 +205,33 @@ pub mod metrics_api {
         });
     }
 
+    /// Record `n` tview rows updated directly by a patch (issue #56).
+    pub fn record_direct_patches_applied(n: u64) {
+        DIRECT_PATCH_METRICS.with(|m| {
+            m.borrow_mut().applied += n;
+        });
+    }
+
+    /// Record `n` patched pks that fell back to recompute (issue #56).
+    pub fn record_direct_patch_fallbacks(n: u64) {
+        DIRECT_PATCH_METRICS.with(|m| {
+            m.borrow_mut().fallbacks += n;
+        });
+    }
+
+    /// Record `n` tview rows recomputed from the backing view (issue #56).
+    pub fn record_view_recomputes(n: u64) {
+        DIRECT_PATCH_METRICS.with(|m| {
+            m.borrow_mut().view_recomputes += n;
+        });
+    }
+
     /// Get current queue statistics
     pub fn get_queue_stats() -> QueueStats {
         // Get current queue size from state
         let queue_size = crate::queue::get_queue_size();
 
-        let direct_patch_captured = DIRECT_PATCH_METRICS.with(|m| m.borrow().captured);
+        let dp = DIRECT_PATCH_METRICS.with(|m| *m.borrow());
 
         METRICS.with(|m| {
             let metrics = m.borrow();
@@ -217,7 +249,10 @@ pub mod metrics_api {
                 prepared_stmt_cache_misses: metrics.prepared_stmt_cache_misses,
                 bulk_refresh_count: metrics.bulk_refresh_count,
                 individual_refresh_count: metrics.individual_refresh_count,
-                direct_patch_captured,
+                direct_patch_captured: dp.captured,
+                direct_patches_applied: dp.applied,
+                direct_patch_fallbacks: dp.fallbacks,
+                view_recomputes: dp.view_recomputes,
             }
         })
     }
@@ -269,8 +304,11 @@ pub struct QueueStats {
     pub prepared_stmt_cache_misses: u64,
     pub bulk_refresh_count: u64,
     pub individual_refresh_count: u64,
-    /// Session-cumulative count of captured direct patches (issue #56).
+    /// Session-cumulative direct-patch counters (issue #56).
     pub direct_patch_captured: u64,
+    pub direct_patches_applied: u64,
+    pub direct_patch_fallbacks: u64,
+    pub view_recomputes: u64,
 }
 
 impl QueueStats {

--- a/src/queue/cache.rs
+++ b/src/queue/cache.rs
@@ -18,28 +18,23 @@ pub struct CachedEntityInfo {
 
     /// Direct-patch column→key map (issue #56): base column name → JSONB key it
     /// feeds in the entity's own `data`. Empty ⇒ the fast path never engages.
-    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
     pub direct_map: HashMap<String, String>,
 
     /// Integer FK columns of this entity's base table. A changed FK is a
     /// membership change ⇒ the fast path must decline (issue #56 eligibility).
-    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
     pub fk_columns: Vec<String>,
 
     /// UUID FK columns of this entity's base table (same membership rule).
-    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
     pub uuid_fk_columns: Vec<String>,
 
     /// Output columns the `tv_<entity>` table materialises (`pk_<entity>`, `id`,
     /// `data`, and any column projected outside `data`). A changed base column that
     /// is also a projected output column would go stale under a data-only patch ⇒
     /// the fast path declines (issue #56 eligibility).
-    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
     pub output_columns: Vec<String>,
 
     /// `true` when the backing view is a UNION / UNION ALL — different refresh
     /// machinery, so the fast path declines (issue #56 eligibility).
-    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
     pub is_union: bool,
 }
 

--- a/src/queue/cache.rs
+++ b/src/queue/cache.rs
@@ -4,12 +4,43 @@ use std::sync::{LazyLock, Mutex, PoisonError};
 
 use crate::cascade_path::CascadePath;
 
-/// Cached information for a table managed by `pg_tviews`
+/// Cached information for a table managed by `pg_tviews`.
+///
+/// Beyond the entity name and DISTINCT ON key, this carries everything the issue
+/// #56 direct-patch eligibility check needs, so the row trigger can decide the fast
+/// path from a single cached lookup with **no SPI in the hot path** (populated once
+/// per session on cache miss, invalidated on DDL).
 #[derive(Clone, Debug)]
 pub struct CachedEntityInfo {
     pub name: String,
     /// First DISTINCT ON key if this is a DISTINCT ON TVIEW, None otherwise
     pub distinct_on_key: Option<String>,
+
+    /// Direct-patch column→key map (issue #56): base column name → JSONB key it
+    /// feeds in the entity's own `data`. Empty ⇒ the fast path never engages.
+    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
+    pub direct_map: HashMap<String, String>,
+
+    /// Integer FK columns of this entity's base table. A changed FK is a
+    /// membership change ⇒ the fast path must decline (issue #56 eligibility).
+    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
+    pub fk_columns: Vec<String>,
+
+    /// UUID FK columns of this entity's base table (same membership rule).
+    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
+    pub uuid_fk_columns: Vec<String>,
+
+    /// Output columns the `tv_<entity>` table materialises (`pk_<entity>`, `id`,
+    /// `data`, and any column projected outside `data`). A changed base column that
+    /// is also a projected output column would go stale under a data-only patch ⇒
+    /// the fast path declines (issue #56 eligibility).
+    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
+    pub output_columns: Vec<String>,
+
+    /// `true` when the backing view is a UNION / UNION ALL — different refresh
+    /// machinery, so the fast path declines (issue #56 eligibility).
+    #[allow(dead_code)] // Reason: consumed by the Phase 2 trigger capture path (issue #56)
+    pub is_union: bool,
 }
 
 /// Global cache for `EntityDepGraph` to avoid repeated `pg_tview_meta` queries
@@ -114,47 +145,59 @@ pub mod table_cache {
         entity_info_cached(table_oid).map(|info| info.map(|i| i.name))
     }
 
-    /// Load entity info from database (name + `distinct_on_key`)
+    /// Load entity info from the database on a cache miss.
+    ///
+    /// Loads the full `TviewMeta` for the entity plus the `tv_<entity>` output
+    /// columns, so a single cached record answers every issue #56 eligibility
+    /// question without further SPI in the trigger hot path.
     fn load_entity_info_uncached(
         table_oid: pg_sys::Oid,
     ) -> crate::TViewResult<Option<CachedEntityInfo>> {
-        let entity_name = crate::catalog::entity_for_table_uncached(table_oid)?;
+        let Some(name) = crate::catalog::entity_for_table_uncached(table_oid)? else {
+            return Ok(None);
+        };
 
-        match entity_name {
-            Some(name) => {
-                // Query distinct_on_keys from pg_tview_meta
-                let distinct_on_key = pgrx::spi::Spi::connect(|client| {
-                    let args = vec![unsafe {
-                        pgrx::datum::DatumWithOid::new(
-                            &name,
-                            pgrx::pg_sys::PgOid::BuiltIn(pgrx::pg_sys::PgBuiltInOids::TEXTOID)
-                                .value(),
-                        )
-                    }];
-                    let mut rows = client.select(
-                        "SELECT distinct_on_keys FROM pg_tview_meta WHERE entity = $1",
-                        None,
-                        &args,
-                    )?;
+        // Name resolved but no meta row (shouldn't happen) → minimal safe info
+        // with the fast path disabled (empty direct_map).
+        let Some(meta) = crate::catalog::TviewMeta::load_by_entity(&name)? else {
+            return Ok(Some(CachedEntityInfo {
+                name,
+                distinct_on_key: None,
+                direct_map: HashMap::new(),
+                fk_columns: Vec::new(),
+                uuid_fk_columns: Vec::new(),
+                output_columns: Vec::new(),
+                is_union: false,
+            }));
+        };
 
-                    let result: Result<Option<String>, pgrx::spi::Error> = match rows.next() {
-                        Some(row) => {
-                            // Extract first element from distinct_on_keys TEXT[] array
-                            let keys: Option<Vec<String>> = row["distinct_on_keys"].value()?;
-                            Ok(keys.and_then(|k| k.first().cloned()))
-                        }
-                        None => Ok(None),
-                    };
-                    result
-                })?;
+        let mut direct_map: HashMap<String, String> = meta
+            .direct_map_columns
+            .iter()
+            .cloned()
+            .zip(meta.direct_map_keys.iter().cloned())
+            .collect();
 
-                Ok(Some(CachedEntityInfo {
-                    name,
-                    distinct_on_key,
-                }))
-            }
-            None => Ok(None),
-        }
+        // Output columns the tv_<entity> table materialises. If they can't be
+        // determined we can't verify the "projected column" eligibility rule, so
+        // disable the fast path for this entity rather than risk a stale column.
+        let output_columns = if let Ok(cols) = crate::utils::get_view_columns_by_oid(meta.tview_oid)
+        {
+            cols
+        } else {
+            direct_map.clear();
+            Vec::new()
+        };
+
+        Ok(Some(CachedEntityInfo {
+            name,
+            distinct_on_key: meta.distinct_on_keys.first().cloned(),
+            direct_map,
+            fk_columns: meta.fk_columns,
+            uuid_fk_columns: meta.uuid_fk_columns,
+            output_columns,
+            is_union: meta.is_union,
+        }))
     }
 
     /// Invalidate the table entity cache
@@ -246,6 +289,11 @@ mod tests {
                 Some(CachedEntityInfo {
                     name: "test".to_string(),
                     distinct_on_key: None,
+                    direct_map: HashMap::new(),
+                    fk_columns: Vec::new(),
+                    uuid_fk_columns: Vec::new(),
+                    output_columns: Vec::new(),
+                    is_union: false,
                 }),
             );
         }
@@ -264,6 +312,34 @@ mod tests {
 
         // Verify it's gone
         assert!(TABLE_ENTITY_CACHE.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_cached_entity_info_carries_direct_patch_fields() {
+        // The cached record exposes everything the issue #56 eligibility check
+        // needs, so the trigger hot path never re-queries pg_tview_meta.
+        let mut direct_map = HashMap::new();
+        direct_map.insert("bio".to_string(), "bio".to_string());
+        direct_map.insert("name".to_string(), "display_name".to_string());
+
+        let info = CachedEntityInfo {
+            name: "user".to_string(),
+            distinct_on_key: None,
+            direct_map,
+            fk_columns: vec!["fk_org".to_string()],
+            uuid_fk_columns: vec![],
+            output_columns: vec!["pk_user".to_string(), "id".to_string(), "data".to_string()],
+            is_union: false,
+        };
+
+        assert_eq!(info.direct_map.get("bio").map(String::as_str), Some("bio"));
+        assert_eq!(
+            info.direct_map.get("name").map(String::as_str),
+            Some("display_name")
+        );
+        assert!(info.fk_columns.contains(&"fk_org".to_string()));
+        assert!(info.output_columns.contains(&"data".to_string()));
+        assert!(!info.is_union);
     }
 
     #[test]

--- a/src/queue/mod.rs
+++ b/src/queue/mod.rs
@@ -11,13 +11,15 @@ pub mod graph;
 mod integration_tests;
 pub mod key;
 mod ops;
+pub mod patch;
 mod state;
 pub mod xact;
 
 pub use graph::EntityDepGraph;
 pub use key::RefreshKey;
 pub use ops::{
-    enqueue_refresh, enqueue_refresh_bulk, enqueue_refresh_dedup, is_queue_empty, spi_batch_lookup,
+    enqueue_refresh, enqueue_refresh_bulk, enqueue_refresh_dedup, enqueue_refresh_patched,
+    is_queue_empty, spi_batch_lookup,
 };
 pub use state::{get_queue_contents, get_queue_size};
 pub use xact::flush_refresh_queue;

--- a/src/queue/ops.rs
+++ b/src/queue/ops.rs
@@ -30,9 +30,35 @@ pub fn enqueue_refresh_with_limit(entity: &str, pk: i64, limit: usize) -> Result
 /// This is the main entry point from triggers for normal TVIEWs.
 /// Deduplication is automatic (`HashSet`).
 /// Raises ERROR if `max_queue_size` would be exceeded.
+///
+/// A plain enqueue **poisons** any direct patch for this key (issue #56): the key
+/// will recompute. Only [`enqueue_refresh_patched`] preserves a fast-path patch.
 pub fn enqueue_refresh(entity: &str, pk: i64) {
     if let Err(msg) = enqueue_refresh_with_limit(entity, pk, crate::config::max_queue_size()) {
         pgrx::error!("{}", msg);
+    }
+    super::patch::poison(RefreshKey::pk(entity, pk));
+}
+
+/// Enqueue a PK-based refresh **and** record a direct patch (issue #56 fast path).
+///
+/// Inserts `(entity, pk)` into the refresh queue under the same backpressure limit
+/// as [`enqueue_refresh`], then records the captured `fields` as a top-level
+/// (`prefix = []`) direct patch. If the key was already poisoned this transaction
+/// (e.g. an INSERT then UPDATE of the same row), the patch is ignored and the key
+/// recomputes — a patch alone cannot materialise a not-yet-created row.
+pub fn enqueue_refresh_patched(
+    entity: &str,
+    pk: i64,
+    fields: serde_json::Map<String, serde_json::Value>,
+) {
+    if let Err(msg) = enqueue_refresh_with_limit(entity, pk, crate::config::max_queue_size()) {
+        pgrx::error!("{}", msg);
+    }
+    // Count the capture once per fresh key: a base table feeding several tviews
+    // has several row triggers that each re-record the same key in one statement.
+    if super::patch::record(RefreshKey::pk(entity, pk), Vec::new(), fields) {
+        crate::metrics::metrics_api::record_direct_patch_captured();
     }
 }
 
@@ -50,6 +76,8 @@ pub fn enqueue_refresh_dedup(entity: &str, dedup_key: &str) {
         });
         q.borrow_mut().insert(RefreshKey::dedup(entity, dedup_key));
     });
+    // Plain enqueue poisons any direct patch for this key (issue #56).
+    super::patch::poison(RefreshKey::dedup(entity, dedup_key));
 }
 
 /// Bulk enqueue PK-based refresh requests for multiple PKs of the same entity.
@@ -64,10 +92,14 @@ pub fn enqueue_refresh_bulk(entity: &str, pks: Vec<i64>) {
             pgrx::error!("{}", msg);
         });
         let mut queue = q.borrow_mut();
-        for pk in pks {
-            queue.insert(RefreshKey::pk(entity, pk));
+        for pk in &pks {
+            queue.insert(RefreshKey::pk(entity, *pk));
         }
     });
+    // Plain (bulk) enqueue poisons any direct patches for these keys (issue #56).
+    for pk in pks {
+        super::patch::poison(RefreshKey::pk(entity, pk));
+    }
 }
 
 /// Take a snapshot of the current queue and clear it

--- a/src/queue/patch.rs
+++ b/src/queue/patch.rs
@@ -1,0 +1,217 @@
+//! Transaction-local patch payloads for the issue #56 direct-patch fast path.
+//!
+//! [`TX_REFRESH_QUEUE`](super::state::TX_REFRESH_QUEUE) (a `HashSet<RefreshKey>`)
+//! stays the dedup/ordering key set; the JSONB payloads ride alongside in
+//! [`TX_PATCH_MAP`], keyed by the same [`RefreshKey`]. A key is either carrying a
+//! usable [`PatchState::Direct`] chain or is [`PatchState::Poisoned`] — an
+//! ineligible change touched it this transaction, so it must recompute. Poison is
+//! sticky.
+//!
+//! The map participates in savepoint snapshot/restore and abort clearing in
+//! lockstep with the queue (see [`super::xact`]) — a patch that survived a
+//! rollback would be a correctness bug, not a missing feature.
+
+use super::key::RefreshKey;
+use serde_json::{Map, Value};
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+/// One link of a patch chain: a JSONB path prefix and the fields to merge there.
+///
+/// An empty prefix targets the entity's own `data` object; a non-empty prefix
+/// (e.g. `["author"]`) targets a nested embedded object — used by parent patch
+/// derivation in Phase 4.
+pub type PatchEntry = (Vec<String>, Map<String, Value>);
+
+/// The patch payload carried for a queued [`RefreshKey`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum PatchState {
+    /// A usable chain of patches to apply directly. Entries with distinct
+    /// prefixes accumulate; a same-prefix merge keeps the later value per key.
+    Direct(Vec<PatchEntry>),
+    /// An ineligible change touched this key this transaction ⇒ recompute.
+    /// Sticky: once poisoned, always poisoned (until abort / savepoint restore).
+    Poisoned,
+}
+
+thread_local! {
+    /// Transaction-local patch payloads keyed by `RefreshKey`. Lives beside
+    /// `TX_REFRESH_QUEUE`; see module docs.
+    pub static TX_PATCH_MAP: RefCell<HashMap<RefreshKey, PatchState>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Record a direct patch for `key`: merge `fields` at `prefix` into any existing
+/// `Direct` chain, or start a new one. A `Poisoned` key stays poisoned (sticky).
+///
+/// Returns `true` iff this inserted a **fresh** `Direct` entry for a previously
+/// unseen key — used to count captures exactly once even when a base table feeds
+/// several tviews (and so has several row triggers that each fire and re-record
+/// the same key within one statement).
+pub fn record(key: RefreshKey, prefix: Vec<String>, fields: Map<String, Value>) -> bool {
+    TX_PATCH_MAP.with(|m| {
+        let mut map = m.borrow_mut();
+        match map.get_mut(&key) {
+            // Sticky poison — a prior ineligible change wins.
+            Some(PatchState::Poisoned) => false,
+            Some(PatchState::Direct(chain)) => {
+                merge_into_chain(chain, prefix, fields);
+                false
+            }
+            None => {
+                map.insert(key, PatchState::Direct(vec![(prefix, fields)]));
+                true
+            }
+        }
+    })
+}
+
+/// Merge `fields` at `prefix` into an existing chain: same prefix ⇒ merge maps
+/// (later value wins per key); a new prefix ⇒ push a new chain entry.
+fn merge_into_chain(chain: &mut Vec<PatchEntry>, prefix: Vec<String>, fields: Map<String, Value>) {
+    if let Some(entry) = chain.iter_mut().find(|(p, _)| *p == prefix) {
+        for (k, v) in fields {
+            entry.1.insert(k, v); // later value wins
+        }
+    } else {
+        chain.push((prefix, fields));
+    }
+}
+
+/// Poison `key`: any existing (or later) direct patch is discarded and the key
+/// recomputes. Idempotent and sticky.
+pub fn poison(key: RefreshKey) {
+    TX_PATCH_MAP.with(|m| {
+        m.borrow_mut().insert(key, PatchState::Poisoned);
+    });
+}
+
+/// Take (and clear) the entire patch map. Used both at flush time (the consumer)
+/// and at savepoint start (to stash the pre-savepoint state).
+pub fn take_patch_snapshot() -> HashMap<RefreshKey, PatchState> {
+    TX_PATCH_MAP.with(|m| std::mem::take(&mut *m.borrow_mut()))
+}
+
+/// Replace the patch map wholesale — savepoint rollback restore.
+pub fn replace_patch_map(new_map: HashMap<RefreshKey, PatchState>) {
+    TX_PATCH_MAP.with(|m| *m.borrow_mut() = new_map);
+}
+
+/// Clear the patch map — transaction abort.
+pub fn clear_patch_map() {
+    TX_PATCH_MAP.with(|m| m.borrow_mut().clear());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(k: &str, v: &str) -> Map<String, Value> {
+        let mut m = Map::new();
+        m.insert(k.to_string(), Value::String(v.to_string()));
+        m
+    }
+
+    fn reset() {
+        clear_patch_map();
+    }
+
+    fn state_of(key: &RefreshKey) -> Option<PatchState> {
+        TX_PATCH_MAP.with(|m| m.borrow().get(key).cloned())
+    }
+
+    #[test]
+    fn merge_same_prefix_later_value_wins() {
+        reset();
+        let key = RefreshKey::pk("user", 1);
+        record(key.clone(), vec![], field("bio", "old"));
+        record(key.clone(), vec![], field("bio", "new"));
+
+        match state_of(&key).unwrap() {
+            PatchState::Direct(chain) => {
+                assert_eq!(chain.len(), 1, "same prefix must merge, not accumulate");
+                assert_eq!(chain[0].1.get("bio").unwrap(), &Value::String("new".into()));
+            }
+            PatchState::Poisoned => panic!("expected Direct"),
+        }
+        reset();
+    }
+
+    #[test]
+    fn merge_same_prefix_unions_distinct_keys() {
+        reset();
+        let key = RefreshKey::pk("user", 1);
+        record(key.clone(), vec![], field("bio", "b"));
+        record(key.clone(), vec![], field("name", "n"));
+
+        match state_of(&key).unwrap() {
+            PatchState::Direct(chain) => {
+                assert_eq!(chain.len(), 1);
+                assert_eq!(chain[0].1.len(), 2);
+                assert!(chain[0].1.contains_key("bio"));
+                assert!(chain[0].1.contains_key("name"));
+            }
+            PatchState::Poisoned => panic!("expected Direct"),
+        }
+        reset();
+    }
+
+    #[test]
+    fn distinct_prefixes_accumulate_entries() {
+        reset();
+        let key = RefreshKey::pk("post", 1);
+        record(key.clone(), vec![], field("title", "t"));
+        record(key.clone(), vec!["author".into()], field("bio", "b"));
+
+        match state_of(&key).unwrap() {
+            PatchState::Direct(chain) => {
+                assert_eq!(chain.len(), 2, "distinct prefixes must accumulate");
+            }
+            PatchState::Poisoned => panic!("expected Direct"),
+        }
+        reset();
+    }
+
+    #[test]
+    fn poison_is_sticky_over_later_record() {
+        reset();
+        let key = RefreshKey::pk("user", 1);
+        poison(key.clone());
+        record(key.clone(), vec![], field("bio", "new"));
+        assert_eq!(state_of(&key), Some(PatchState::Poisoned));
+        reset();
+    }
+
+    #[test]
+    fn record_then_poison_overwrites_to_poison() {
+        reset();
+        let key = RefreshKey::pk("user", 1);
+        record(key.clone(), vec![], field("bio", "new"));
+        poison(key.clone());
+        assert_eq!(state_of(&key), Some(PatchState::Poisoned));
+        reset();
+    }
+
+    #[test]
+    fn snapshot_take_clears_and_restore_round_trips() {
+        reset();
+        let key = RefreshKey::pk("user", 1);
+        record(key.clone(), vec![], field("bio", "b"));
+
+        let snap = take_patch_snapshot();
+        assert!(state_of(&key).is_none(), "take must clear the live map");
+        assert_eq!(snap.len(), 1);
+
+        replace_patch_map(snap);
+        assert!(matches!(state_of(&key), Some(PatchState::Direct(_))));
+        reset();
+    }
+
+    #[test]
+    fn clear_empties_the_map() {
+        reset();
+        record(RefreshKey::pk("user", 1), vec![], field("bio", "b"));
+        clear_patch_map();
+        assert!(take_patch_snapshot().is_empty());
+    }
+}

--- a/src/queue/patch.rs
+++ b/src/queue/patch.rs
@@ -102,6 +102,40 @@ pub fn clear_patch_map() {
     TX_PATCH_MAP.with(|m| m.borrow_mut().clear());
 }
 
+// ── Flush-local map operations (issue #56 Phase 4) ───────────────────────────
+//
+// Parent patch derivation happens against the flush's *local* snapshot map, not
+// the thread-local `TX_PATCH_MAP` (already drained). These mirror `record`/`poison`
+// but operate on a caller-owned map.
+
+/// Merge a derived `chain` into `map` for `key` (same rules as [`record`]): a
+/// `Poisoned` key stays poisoned; a `Direct` key merges each entry; an absent key
+/// starts a new `Direct`.
+pub fn merge_chain_into(
+    map: &mut HashMap<RefreshKey, PatchState>,
+    key: RefreshKey,
+    chain: Vec<PatchEntry>,
+) {
+    match map.get_mut(&key) {
+        Some(PatchState::Poisoned) => {}
+        Some(PatchState::Direct(existing)) => {
+            for (prefix, fields) in chain {
+                merge_into_chain(existing, prefix, fields);
+            }
+        }
+        None => {
+            map.insert(key, PatchState::Direct(chain));
+        }
+    }
+}
+
+/// Poison `key` in `map` (sticky) — the parent must recompute. Used when a parent
+/// is reached from a recomputed child, or from a child whose dependency can't take
+/// a path patch (array/scalar/uuid-fk).
+pub fn poison_into(map: &mut HashMap<RefreshKey, PatchState>, key: RefreshKey) {
+    map.insert(key, PatchState::Poisoned);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/queue/patch.rs
+++ b/src/queue/patch.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 ///
 /// An empty prefix targets the entity's own `data` object; a non-empty prefix
 /// (e.g. `["author"]`) targets a nested embedded object — used by parent patch
-/// derivation in Phase 4.
+/// derivation (issue #56).
 pub type PatchEntry = (Vec<String>, Map<String, Value>);
 
 /// The patch payload carried for a queued [`RefreshKey`].
@@ -102,7 +102,7 @@ pub fn clear_patch_map() {
     TX_PATCH_MAP.with(|m| m.borrow_mut().clear());
 }
 
-// ── Flush-local map operations (issue #56 Phase 4) ───────────────────────────
+// ── Flush-local map operations (issue #56) ───────────────────────────
 //
 // Parent patch derivation happens against the flush's *local* snapshot map, not
 // the thread-local `TX_PATCH_MAP` (already drained). These mirror `record`/`poison`

--- a/src/queue/xact.rs
+++ b/src/queue/xact.rs
@@ -17,6 +17,13 @@ thread_local! {
     /// Queue snapshots for each savepoint level
     static QUEUE_SNAPSHOTS: std::cell::RefCell<Vec<HashSet<super::key::RefreshKey>>> =
         const { std::cell::RefCell::new(Vec::new()) };
+
+    /// Direct-patch map snapshots for each savepoint level (issue #56).
+    /// Kept in lockstep with `QUEUE_SNAPSHOTS` so a patch rolls back exactly when
+    /// its queue entry does.
+    static PATCH_SNAPSHOTS: std::cell::RefCell<
+        Vec<std::collections::HashMap<super::key::RefreshKey, super::patch::PatchState>>,
+    > = const { std::cell::RefCell::new(Vec::new()) };
 }
 
 /// Transaction event types
@@ -63,6 +70,14 @@ pub unsafe fn register_subxact_callback() {
         let mut snapshots = s.borrow_mut();
         for _ in 0..(nest_level as usize).saturating_sub(1) {
             snapshots.push(HashSet::new());
+        }
+    });
+
+    // Mirror the placeholders for the patch-map snapshot stack (issue #56).
+    PATCH_SNAPSHOTS.with(|s| {
+        let mut snapshots = s.borrow_mut();
+        for _ in 0..(nest_level as usize).saturating_sub(1) {
+            snapshots.push(std::collections::HashMap::new());
         }
     });
 }
@@ -129,6 +144,7 @@ unsafe extern "C-unwind" fn tview_xact_callback(event: u32, _arg: *mut c_void) {
             crate::suspend::force_resume();
 
             clear_queue();
+            super::patch::clear_patch_map();
             super::ops::clear_crash_recovery_cache();
             super::cache::cascade_cache::clear_cache();
             crate::audit::clear_audit_buffer();
@@ -166,6 +182,12 @@ unsafe extern "C-unwind" fn tview_subxact_callback(
                 QUEUE_SNAPSHOTS.with(|s| {
                     s.borrow_mut().push(snapshot);
                 });
+
+                // Snapshot the patch map in lockstep (issue #56).
+                let patch_snapshot = super::patch::take_patch_snapshot();
+                PATCH_SNAPSHOTS.with(|s| {
+                    s.borrow_mut().push(patch_snapshot);
+                });
             }
             pg_sys::SubXactEvent::SUBXACT_EVENT_ABORT_SUB => {
                 // ROLLBACK TO SAVEPOINT: restore queue to snapshot
@@ -176,13 +198,21 @@ unsafe extern "C-unwind" fn tview_subxact_callback(
                     // Replace current queue with the snapshot
                     super::state::replace_queue(snapshot);
                 }
+
+                // Restore the patch map in lockstep (issue #56).
+                if let Some(patch_snapshot) = PATCH_SNAPSHOTS.with(|s| s.borrow_mut().pop()) {
+                    super::patch::replace_patch_map(patch_snapshot);
+                }
             }
             pg_sys::SubXactEvent::SUBXACT_EVENT_COMMIT_SUB => {
                 // RELEASE SAVEPOINT: just decrement depth and discard snapshot
                 decrement_savepoint_depth();
 
-                // Discard the snapshot (savepoint committed)
+                // Discard the snapshots (savepoint committed)
                 QUEUE_SNAPSHOTS.with(|s| {
+                    s.borrow_mut().pop();
+                });
+                PATCH_SNAPSHOTS.with(|s| {
                     s.borrow_mut().pop();
                 });
             }
@@ -243,6 +273,11 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
     if pending.is_empty() {
         return Ok(());
     }
+
+    // Issue #56: drain the direct-patch map in lockstep with the queue so it never
+    // outlives its queue entries. Phase 2 discards these; Phase 3 consumes them to
+    // apply direct patches instead of recomputing.
+    let _patches = super::patch::take_patch_snapshot();
 
     // Start timing the entire refresh operation
     let refresh_timer = crate::metrics::metrics_api::record_refresh_start();
@@ -359,6 +394,8 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
         if late.is_empty() {
             break;
         }
+        // Keep the patch map in lockstep with the late-enqueue drain (issue #56).
+        let _late_patches = super::patch::take_patch_snapshot();
         pending = late;
     }
 

--- a/src/queue/xact.rs
+++ b/src/queue/xact.rs
@@ -290,6 +290,13 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
     let mut processed: std::collections::HashSet<super::key::RefreshKey> =
         std::collections::HashSet::with_capacity(pending.len().max(16));
 
+    // Parent metadata cache for patch derivation (issue #56 Phase 4) — avoids
+    // reloading a parent entity's TviewMeta once per discovered parent key.
+    let mut parent_meta_cache: std::collections::HashMap<
+        String,
+        Option<crate::catalog::TviewMeta>,
+    > = std::collections::HashMap::new();
+
     // Outer drain loop: after the inner loop empties `pending`, check for
     // late-enqueued items from triggers that fired during refresh (e.g.,
     // pg_treekey cascading child rows in tb_location).  The `processed` set
@@ -373,10 +380,13 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
                 }
 
                 // Recompute the remaining keys via the existing single/bulk path.
+                // A recomputed child's whole document changed, so its parents must
+                // recompute too: poison any parent patch (issue #56 Phase 4).
                 if recompute_keys.len() == 1 {
                     let key = &recompute_keys[0];
                     let parents = refresh_and_get_parents(key, &graph)?;
                     for parent_key in parents {
+                        super::patch::poison_into(&mut patches, parent_key.clone());
                         if !processed.contains(&parent_key) {
                             pending.insert(parent_key);
                         }
@@ -395,6 +405,7 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
                     let parent_map = crate::propagate::find_parents_batch(&recompute_keys, &graph)?;
                     for parent_keys in parent_map.values() {
                         for parent_key in parent_keys {
+                            super::patch::poison_into(&mut patches, parent_key.clone());
                             if !processed.contains(parent_key) {
                                 pending.insert(parent_key.clone());
                             }
@@ -402,17 +413,49 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
                     }
                 }
 
-                // Parent discovery for the patched keys that applied (they were not
-                // recomputed above). In this phase parents are plain recompute keys;
-                // Phase 4 derives patches for them.
+                // Parent patch derivation for the patched keys that applied (issue
+                // #56 Phase 4). For each parent embedding the child via a
+                // nested_object dependency, prepend the dependency path to the
+                // child's chain and record it for the parent; where a patch can't be
+                // derived (array/scalar/uuid-fk dep, or the parent itself gated), the
+                // parent is poisoned and recomputes. Poison stickiness means a parent
+                // reached by both a patched and a recomputed child recomputes.
                 if !applied_pks.is_empty() {
                     let applied_keys: Vec<super::key::RefreshKey> = applied_pks
                         .iter()
                         .map(|&pk| super::key::RefreshKey::pk(&entity, pk))
                         .collect();
                     let parent_map = crate::propagate::find_parents_batch(&applied_keys, &graph)?;
-                    for parent_keys in parent_map.values() {
+                    for (child_key, parent_keys) in &parent_map {
+                        // Snapshot the child's applied chain before mutating `patches`.
+                        let child_chain = match patches.get(child_key) {
+                            Some(super::patch::PatchState::Direct(chain)) => Some(chain.clone()),
+                            _ => None,
+                        };
                         for parent_key in parent_keys {
+                            let derived = match &child_chain {
+                                Some(chain) => {
+                                    load_meta_cached(&parent_key.entity, &mut parent_meta_cache)?
+                                        .and_then(|m| {
+                                            crate::refresh::direct::derive_parent_chain(
+                                                &m,
+                                                &child_key.entity,
+                                                chain,
+                                            )
+                                        })
+                                }
+                                None => None,
+                            };
+                            match derived {
+                                Some(chain) => super::patch::merge_chain_into(
+                                    &mut patches,
+                                    parent_key.clone(),
+                                    chain,
+                                ),
+                                None => {
+                                    super::patch::poison_into(&mut patches, parent_key.clone());
+                                }
+                            }
                             if !processed.contains(parent_key) {
                                 pending.insert(parent_key.clone());
                             }
@@ -466,6 +509,22 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
     );
 
     Ok(())
+}
+
+/// Load and cache a parent entity's `TviewMeta` for patch derivation (issue #56).
+///
+/// The cache lives for the duration of one flush; parent entities are few, so this
+/// keeps derivation from re-querying `pg_tview_meta` per discovered parent key.
+fn load_meta_cached(
+    entity: &str,
+    cache: &mut std::collections::HashMap<String, Option<crate::catalog::TviewMeta>>,
+) -> spi::Result<Option<crate::catalog::TviewMeta>> {
+    if let Some(meta) = cache.get(entity) {
+        return Ok(meta.clone());
+    }
+    let meta = crate::catalog::TviewMeta::load_by_entity(entity)?;
+    cache.insert(entity.to_string(), meta.clone());
+    Ok(meta)
 }
 
 /// Refresh a single entity+pk and return discovered parent keys (without refreshing them)

--- a/src/queue/xact.rs
+++ b/src/queue/xact.rs
@@ -275,9 +275,9 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
     }
 
     // Issue #56: drain the direct-patch map in lockstep with the queue so it never
-    // outlives its queue entries. Phase 2 discards these; Phase 3 consumes them to
-    // apply direct patches instead of recomputing.
-    let _patches = super::patch::take_patch_snapshot();
+    // outlives its queue entries. Keys carrying a usable `Direct` chain are patched
+    // straight into tv_<entity>; everything else recomputes.
+    let mut patches = super::patch::take_patch_snapshot();
 
     // Start timing the entire refresh operation
     let refresh_timer = crate::metrics::metrics_api::record_refresh_start();
@@ -336,37 +336,81 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
                     }
                 }
 
-                if entity_keys.len() == 1 {
-                    // Single key: use existing individual refresh
-                    let key = &entity_keys[0];
-                    let parents = refresh_and_get_parents(key, &graph)?;
+                // Issue #56: split off keys carrying a usable direct patch. They are
+                // applied straight to tv_<entity> (no backing-view query); everything
+                // else — poisoned keys, dedup keys, keys with no patch, or the fast
+                // path disabled — recomputes exactly as before. The GUC is re-checked
+                // here so toggling it off between capture and commit forces recompute.
+                let apply_enabled = crate::config::direct_patch_enabled();
+                let mut patched: Vec<(i64, Vec<super::patch::PatchEntry>)> = Vec::new();
+                let mut applied_pks: HashSet<i64> = HashSet::new();
+                let mut recompute_keys: Vec<super::key::RefreshKey> = Vec::new();
+                for key in entity_keys {
+                    if apply_enabled
+                        && !key.is_dedup()
+                        && let Some(super::patch::PatchState::Direct(chain)) = patches.get(&key)
+                    {
+                        patched.push((key.pk, chain.clone()));
+                        applied_pks.insert(key.pk);
+                        continue;
+                    }
+                    recompute_keys.push(key);
+                }
 
-                    // Add discovered parents to pending queue
+                // Apply direct patches; any pk whose tview row is missing falls back.
+                if !patched.is_empty() {
+                    let meta =
+                        crate::catalog::TviewMeta::load_by_entity(&entity)?.ok_or_else(|| {
+                            crate::TViewError::MetadataNotFound {
+                                entity: entity.clone(),
+                            }
+                        })?;
+                    let fallback = crate::refresh::direct::apply_entity_patches(&meta, patched)?;
+                    for pk in fallback {
+                        applied_pks.remove(&pk);
+                        recompute_keys.push(super::key::RefreshKey::pk(&entity, pk));
+                    }
+                }
+
+                // Recompute the remaining keys via the existing single/bulk path.
+                if recompute_keys.len() == 1 {
+                    let key = &recompute_keys[0];
+                    let parents = refresh_and_get_parents(key, &graph)?;
                     for parent_key in parents {
                         if !processed.contains(&parent_key) {
                             pending.insert(parent_key);
                         }
                     }
-                } else {
-                    // Multiple keys for same entity: use bulk refresh (PK-only path)
-                    // Pre-allocate Vec based on PK-only keys (exclude dedup keys)
+                } else if recompute_keys.len() > 1 {
                     let mut pks =
-                        Vec::with_capacity(entity_keys.iter().filter(|k| !k.is_dedup()).count());
-                    for key in &entity_keys {
+                        Vec::with_capacity(recompute_keys.iter().filter(|k| !k.is_dedup()).count());
+                    for key in &recompute_keys {
                         if !key.is_dedup() {
                             pks.push(key.pk);
                         }
                     }
-
-                    // Bulk refresh this entity
                     // FAIL-FAST: Propagate error immediately to abort transaction
                     crate::refresh::refresh_bulk(&entity, &pks)?;
 
-                    // Discover parents for all keys in this entity group (P-07: batched)
-                    // Instead of N × M separate queries, issue M batched queries (one per parent entity)
-                    let parent_map = crate::propagate::find_parents_batch(&entity_keys, &graph)?;
+                    let parent_map = crate::propagate::find_parents_batch(&recompute_keys, &graph)?;
+                    for parent_keys in parent_map.values() {
+                        for parent_key in parent_keys {
+                            if !processed.contains(parent_key) {
+                                pending.insert(parent_key.clone());
+                            }
+                        }
+                    }
+                }
 
-                    // Add discovered parents to pending queue
+                // Parent discovery for the patched keys that applied (they were not
+                // recomputed above). In this phase parents are plain recompute keys;
+                // Phase 4 derives patches for them.
+                if !applied_pks.is_empty() {
+                    let applied_keys: Vec<super::key::RefreshKey> = applied_pks
+                        .iter()
+                        .map(|&pk| super::key::RefreshKey::pk(&entity, pk))
+                        .collect();
+                    let parent_map = crate::propagate::find_parents_batch(&applied_keys, &graph)?;
                     for parent_keys in parent_map.values() {
                         for parent_key in parent_keys {
                             if !processed.contains(parent_key) {
@@ -394,8 +438,10 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
         if late.is_empty() {
             break;
         }
-        // Keep the patch map in lockstep with the late-enqueue drain (issue #56).
-        let _late_patches = super::patch::take_patch_snapshot();
+        // Merge patches captured by triggers that fired during refresh (issue #56).
+        for (k, v) in super::patch::take_patch_snapshot() {
+            patches.insert(k, v);
+        }
         pending = late;
     }
 

--- a/src/queue/xact.rs
+++ b/src/queue/xact.rs
@@ -290,7 +290,7 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
     let mut processed: std::collections::HashSet<super::key::RefreshKey> =
         std::collections::HashSet::with_capacity(pending.len().max(16));
 
-    // Parent metadata cache for patch derivation (issue #56 Phase 4) — avoids
+    // Parent metadata cache for patch derivation (issue #56) — avoids
     // reloading a parent entity's TviewMeta once per discovered parent key.
     let mut parent_meta_cache: std::collections::HashMap<
         String,
@@ -381,7 +381,7 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
 
                 // Recompute the remaining keys via the existing single/bulk path.
                 // A recomputed child's whole document changed, so its parents must
-                // recompute too: poison any parent patch (issue #56 Phase 4).
+                // recompute too: poison any parent patch (issue #56).
                 if recompute_keys.len() == 1 {
                     let key = &recompute_keys[0];
                     let parents = refresh_and_get_parents(key, &graph)?;
@@ -414,7 +414,7 @@ pub fn flush_refresh_queue() -> TViewResult<()> {
                 }
 
                 // Parent patch derivation for the patched keys that applied (issue
-                // #56 Phase 4). For each parent embedding the child via a
+                // #56). For each parent embedding the child via a
                 // nested_object dependency, prepend the dependency path to the
                 // child's chain and record it for the parent; where a patch can't be
                 // derived (array/scalar/uuid-fk dep, or the parent itself gated), the

--- a/src/refresh/bulk.rs
+++ b/src/refresh/bulk.rs
@@ -45,6 +45,9 @@ pub fn refresh_bulk(entity: &str, pks: &[i64]) -> TViewResult<()> {
         return Ok(());
     }
 
+    // Count the backing-view recompute of these rows (issue #56).
+    crate::metrics::metrics_api::record_view_recomputes(pks.len() as u64);
+
     // Load metadata once
     let meta =
         TviewMeta::load_by_entity(entity)?.ok_or_else(|| crate::TViewError::MetadataNotFound {

--- a/src/refresh/direct.rs
+++ b/src/refresh/direct.rs
@@ -92,7 +92,7 @@ pub fn apply_direct_patch(
 
     let tv_name = crate::utils::relname_from_oid(meta.tview_oid)?;
     let pk_col = format!("pk_{}", meta.entity_name);
-    let patch_expr = build_direct_patch_expr(chain);
+    let (patch_expr, path_args) = build_direct_patch_expr(chain);
     let pk_param = chain.len() + 1;
 
     let sql = format!(
@@ -100,9 +100,10 @@ pub fn apply_direct_patch(
          WHERE {pk_col} = ANY(${pk_param}) RETURNING {pk_col}"
     );
 
-    // Params: one JSONB per chain entry (in order), then the pk array.
-    // SAFETY: DatumWithOid wraps validated structured data (JSONB documents and a
-    // BIGINT[]) for SPI parameter passing.
+    // Params (all bound, nothing interpolated): one JSONB per chain entry, then the
+    // pk array, then one text[] per nested-entry path.
+    // SAFETY: DatumWithOid wraps validated structured data (JSONB documents, a
+    // BIGINT[], and TEXT[] paths from catalog-parsed dependency metadata) for SPI.
     let json_args: Vec<pgrx::JsonB> = chain
         .iter()
         .map(|(_, fields)| pgrx::JsonB(Value::Object(fields.clone())))
@@ -110,7 +111,7 @@ pub fn apply_direct_patch(
     let pk_vec = pks.to_vec();
 
     Spi::connect(|client| {
-        let mut args: Vec<DatumWithOid> = Vec::with_capacity(chain.len() + 1);
+        let mut args: Vec<DatumWithOid> = Vec::with_capacity(chain.len() + 1 + path_args.len());
         for j in &json_args {
             args.push(unsafe {
                 DatumWithOid::new(
@@ -125,6 +126,14 @@ pub fn apply_direct_patch(
                 PgOid::BuiltIn(PgBuiltInOids::INT8ARRAYOID).value(),
             )
         });
+        for path in &path_args {
+            args.push(unsafe {
+                DatumWithOid::new(
+                    path.clone(),
+                    PgOid::BuiltIn(PgBuiltInOids::TEXTARRAYOID).value(),
+                )
+            });
+        }
 
         let rows = client.select(&sql, None, &args)?;
         let mut updated = Vec::new();
@@ -178,27 +187,36 @@ pub fn apply_entity_patches(
 }
 
 /// Build the nested `jsonb_smart_patch_*` expression for a chain, innermost first
-/// (the existing `data` column). Each entry contributes one call and one `$n`
-/// JSONB parameter:
-/// - empty prefix ⇒ `jsonb_smart_patch_scalar(expr, $n::jsonb)` (top-level merge),
-/// - non-empty prefix ⇒ `jsonb_smart_patch_nested(expr, $n::jsonb, ARRAY[...])`.
-fn build_direct_patch_expr(chain: &[PatchEntry]) -> String {
+/// (the existing `data` column), and collect the path arrays to bind.
+///
+/// Everything is parameterized — no value or identifier is interpolated. Parameter
+/// layout for a chain of `n` entries: `$1..$n` = the JSONB fields (one per entry),
+/// `$(n+1)` = the pk array, `$(n+2)..` = one `text[]` per nested entry (in order).
+/// Each entry contributes one call:
+/// - empty prefix ⇒ `jsonb_smart_patch_scalar(expr, $i::jsonb)` (top-level merge),
+/// - non-empty prefix ⇒ `jsonb_smart_patch_nested(expr, $i::jsonb, $p::text[])`
+///   with the path bound as a parameter (never an interpolated `ARRAY['…']`).
+///
+/// Returns `(sql_expr, path_args)` where `path_args` are the path arrays to bind
+/// after the JSONB fields and the pk array, in order.
+fn build_direct_patch_expr(chain: &[PatchEntry]) -> (String, Vec<Vec<String>>) {
+    let n = chain.len();
     let mut expr = "data".to_string();
+    let mut path_args: Vec<Vec<String>> = Vec::new();
     for (i, (prefix, _fields)) in chain.iter().enumerate() {
-        let param = i + 1;
+        let json_param = i + 1;
         if prefix.is_empty() {
-            expr = format!("jsonb_smart_patch_scalar({expr}, ${param}::jsonb)");
+            expr = format!("jsonb_smart_patch_scalar({expr}, ${json_param}::jsonb)");
         } else {
-            let path_literal = prefix
-                .iter()
-                .map(|seg| format!("'{}'", seg.replace('\'', "''")))
-                .collect::<Vec<_>>()
-                .join(", ");
-            expr =
-                format!("jsonb_smart_patch_nested({expr}, ${param}::jsonb, ARRAY[{path_literal}])");
+            // Path params follow the n JSONB params and the single pk-array param.
+            let path_param = n + 2 + path_args.len();
+            path_args.push(prefix.clone());
+            expr = format!(
+                "jsonb_smart_patch_nested({expr}, ${json_param}::jsonb, ${path_param}::text[])"
+            );
         }
     }
-    expr
+    (expr, path_args)
 }
 
 #[cfg(test)]
@@ -214,47 +232,54 @@ mod tests {
 
     #[test]
     fn top_level_chain_builds_scalar_merge() {
-        let chain = vec![entry(&[], "bio", "x")];
-        assert_eq!(
-            build_direct_patch_expr(&chain),
-            "jsonb_smart_patch_scalar(data, $1::jsonb)"
-        );
+        let (expr, paths) = build_direct_patch_expr(&[entry(&[], "bio", "x")]);
+        assert_eq!(expr, "jsonb_smart_patch_scalar(data, $1::jsonb)");
+        assert!(paths.is_empty());
     }
 
     #[test]
-    fn nested_prefix_builds_nested_call() {
-        let chain = vec![entry(&["author"], "bio", "x")];
+    fn nested_prefix_binds_path_param() {
+        // Chain of 1 ⇒ $1 = fields, $2 = pk array, $3 = the path text[].
+        let (expr, paths) = build_direct_patch_expr(&[entry(&["author"], "bio", "x")]);
         assert_eq!(
-            build_direct_patch_expr(&chain),
-            "jsonb_smart_patch_nested(data, $1::jsonb, ARRAY['author'])"
+            expr,
+            "jsonb_smart_patch_nested(data, $1::jsonb, $3::text[])"
         );
+        assert_eq!(paths, vec![vec!["author".to_string()]]);
     }
 
     #[test]
-    fn two_level_prefix_lists_both_segments() {
-        let chain = vec![entry(&["post", "author"], "bio", "x")];
+    fn two_level_path_bound_as_array_param() {
+        let (expr, paths) = build_direct_patch_expr(&[entry(&["post", "author"], "bio", "x")]);
         assert_eq!(
-            build_direct_patch_expr(&chain),
-            "jsonb_smart_patch_nested(data, $1::jsonb, ARRAY['post', 'author'])"
+            expr,
+            "jsonb_smart_patch_nested(data, $1::jsonb, $3::text[])"
         );
+        assert_eq!(paths, vec![vec!["post".to_string(), "author".to_string()]]);
     }
 
     #[test]
-    fn mixed_chain_nests_calls_in_order() {
+    fn mixed_chain_nests_calls_and_numbers_path_after_pk() {
+        // 2 entries ⇒ $1,$2 = fields, $3 = pk array, $4 = the nested entry's path.
         let chain = vec![entry(&[], "title", "t"), entry(&["author"], "bio", "b")];
+        let (expr, paths) = build_direct_patch_expr(&chain);
         assert_eq!(
-            build_direct_patch_expr(&chain),
-            "jsonb_smart_patch_nested(jsonb_smart_patch_scalar(data, $1::jsonb), $2::jsonb, ARRAY['author'])"
+            expr,
+            "jsonb_smart_patch_nested(jsonb_smart_patch_scalar(data, $1::jsonb), $2::jsonb, $4::text[])"
         );
+        assert_eq!(paths, vec![vec!["author".to_string()]]);
     }
 
     #[test]
-    fn single_quote_in_path_segment_is_escaped() {
-        let chain = vec![entry(&["we'ird"], "k", "v")];
+    fn exotic_path_segment_is_bound_not_interpolated() {
+        // A quote in a segment is carried verbatim as a bound parameter — never
+        // escaped into SQL — so there is no interpolation surface at all.
+        let (expr, paths) = build_direct_patch_expr(&[entry(&["we'ird"], "k", "v")]);
         assert_eq!(
-            build_direct_patch_expr(&chain),
-            "jsonb_smart_patch_nested(data, $1::jsonb, ARRAY['we''ird'])"
+            expr,
+            "jsonb_smart_patch_nested(data, $1::jsonb, $3::text[])"
         );
+        assert_eq!(paths, vec![vec!["we'ird".to_string()]]);
     }
 
     // ── derive_parent_chain (issue #56) ─────────────────────────────────────

--- a/src/refresh/direct.rs
+++ b/src/refresh/direct.rs
@@ -12,7 +12,7 @@ use pgrx::prelude::*;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 
-/// Derive a parent's patch chain from a patched child's chain (issue #56 Phase 4).
+/// Derive a parent's patch chain from a patched child's chain (issue #56).
 ///
 /// When `parent_meta` embeds `child_entity` via a `nested_object` dependency at a
 /// concrete path, the child's chain is reproduced at the parent with that path
@@ -257,7 +257,7 @@ mod tests {
         );
     }
 
-    // ── derive_parent_chain (Phase 4 Cycle 1) ────────────────────────────────
+    // ── derive_parent_chain (issue #56) ─────────────────────────────────────
 
     /// A parent `TviewMeta` with a single dependency on `fk_<child>`.
     fn parent_meta(fk: &str, dep: DependencyType, path: Option<Vec<String>>) -> TviewMeta {

--- a/src/refresh/direct.rs
+++ b/src/refresh/direct.rs
@@ -5,12 +5,75 @@
 //! backing-view queries. Any pk whose tview row does not yet exist is reported
 //! back so the caller recomputes it (a patch can only update an existing row).
 
-use crate::catalog::TviewMeta;
+use crate::catalog::{DependencyType, TviewMeta};
 use crate::queue::patch::PatchEntry;
 use pgrx::datum::DatumWithOid;
 use pgrx::prelude::*;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
+
+/// Derive a parent's patch chain from a patched child's chain (issue #56 Phase 4).
+///
+/// When `parent_meta` embeds `child_entity` via a `nested_object` dependency at a
+/// concrete path, the child's chain is reproduced at the parent with that path
+/// prepended to every entry's prefix — `([], {bio})` for `user` becomes
+/// `(["author"], {bio})` for `post`. Multi-level cascades compose by prepending
+/// again. Returns `None` (⇒ the parent must recompute) when:
+/// - the parent is itself DISTINCT ON or a UNION,
+/// - the linkage is UUID-fk based (different plumbing, out of scope),
+/// - there is no `fk_<child>` dependency, or it appears more than once (ambiguous),
+/// - the dependency is not `nested_object`, or has no/empty path (array/scalar can't
+///   take a path patch — interlock with #50).
+pub fn derive_parent_chain(
+    parent_meta: &TviewMeta,
+    child_entity: &str,
+    child_chain: &[PatchEntry],
+) -> Option<Vec<PatchEntry>> {
+    // Parent must itself clear the entity-level gates.
+    if !parent_meta.distinct_on_keys.is_empty() || parent_meta.is_union {
+        return None;
+    }
+
+    let fk_name = format!("fk_{child_entity}");
+
+    // UUID-fk linkage uses different plumbing — decline in this cut.
+    if parent_meta.uuid_fk_columns.contains(&fk_name) {
+        return None;
+    }
+
+    // Locate the dependency by fk column; ambiguous (embedded under multiple keys)
+    // or absent ⇒ decline.
+    let mut idx = None;
+    for (i, col) in parent_meta.fk_columns.iter().enumerate() {
+        if *col == fk_name {
+            if idx.is_some() {
+                return None; // more than one — ambiguous
+            }
+            idx = Some(i);
+        }
+    }
+    let idx = idx?;
+
+    // Must be a NestedObject dependency with a concrete, non-empty path.
+    if parent_meta.dependency_types.get(idx)? != &DependencyType::NestedObject {
+        return None;
+    }
+    let path = parent_meta.dependency_paths.get(idx)?.as_ref()?;
+    if path.is_empty() {
+        return None;
+    }
+
+    // Prepend the dependency path to every chain entry's prefix.
+    let derived = child_chain
+        .iter()
+        .map(|(prefix, fields)| {
+            let mut new_prefix = path.clone();
+            new_prefix.extend(prefix.iter().cloned());
+            (new_prefix, fields.clone())
+        })
+        .collect();
+    Some(derived)
+}
 
 /// Apply one patch chain to a set of rows of a single entity.
 ///
@@ -192,5 +255,122 @@ mod tests {
             build_direct_patch_expr(&chain),
             "jsonb_smart_patch_nested(data, $1::jsonb, ARRAY['we''ird'])"
         );
+    }
+
+    // ── derive_parent_chain (Phase 4 Cycle 1) ────────────────────────────────
+
+    /// A parent `TviewMeta` with a single dependency on `fk_<child>`.
+    fn parent_meta(fk: &str, dep: DependencyType, path: Option<Vec<String>>) -> TviewMeta {
+        TviewMeta {
+            fk_columns: vec![fk.to_string()],
+            dependency_types: vec![dep],
+            dependency_paths: vec![path],
+            ..TviewMeta::default()
+        }
+    }
+
+    #[test]
+    fn nested_object_dep_prepends_path() {
+        let meta = parent_meta(
+            "fk_user",
+            DependencyType::NestedObject,
+            Some(vec!["author".to_string()]),
+        );
+        let child = vec![entry(&[], "bio", "x")];
+        let derived = derive_parent_chain(&meta, "user", &child).unwrap();
+        assert_eq!(derived.len(), 1);
+        assert_eq!(derived[0].0, vec!["author".to_string()]);
+        assert_eq!(derived[0].1.get("bio").unwrap(), &Value::String("x".into()));
+    }
+
+    #[test]
+    fn array_dep_declines() {
+        let meta = parent_meta(
+            "fk_comment",
+            DependencyType::Array,
+            Some(vec!["comments".to_string()]),
+        );
+        assert!(derive_parent_chain(&meta, "comment", &[entry(&[], "b", "x")]).is_none());
+    }
+
+    #[test]
+    fn scalar_dep_declines() {
+        let meta = parent_meta("fk_user", DependencyType::Scalar, None);
+        assert!(derive_parent_chain(&meta, "user", &[entry(&[], "b", "x")]).is_none());
+    }
+
+    #[test]
+    fn nested_without_path_declines() {
+        let meta = parent_meta("fk_user", DependencyType::NestedObject, None);
+        assert!(derive_parent_chain(&meta, "user", &[entry(&[], "b", "x")]).is_none());
+    }
+
+    #[test]
+    fn uuid_fk_linkage_declines() {
+        let mut meta = parent_meta(
+            "fk_user",
+            DependencyType::NestedObject,
+            Some(vec!["author".to_string()]),
+        );
+        meta.uuid_fk_columns = vec!["fk_user".to_string()];
+        assert!(derive_parent_chain(&meta, "user", &[entry(&[], "b", "x")]).is_none());
+    }
+
+    #[test]
+    fn duplicate_embedding_declines() {
+        let mut meta = parent_meta(
+            "fk_user",
+            DependencyType::NestedObject,
+            Some(vec!["author".to_string()]),
+        );
+        // Same fk appears twice → ambiguous which key to patch.
+        meta.fk_columns.push("fk_user".to_string());
+        meta.dependency_types.push(DependencyType::NestedObject);
+        meta.dependency_paths.push(Some(vec!["editor".to_string()]));
+        assert!(derive_parent_chain(&meta, "user", &[entry(&[], "b", "x")]).is_none());
+    }
+
+    #[test]
+    fn missing_dependency_declines() {
+        let meta = parent_meta(
+            "fk_other",
+            DependencyType::NestedObject,
+            Some(vec!["x".to_string()]),
+        );
+        assert!(derive_parent_chain(&meta, "user", &[entry(&[], "b", "x")]).is_none());
+    }
+
+    #[test]
+    fn distinct_on_or_union_parent_declines() {
+        let mut meta = parent_meta(
+            "fk_user",
+            DependencyType::NestedObject,
+            Some(vec!["author".to_string()]),
+        );
+        meta.distinct_on_keys = vec!["id".to_string()];
+        assert!(derive_parent_chain(&meta, "user", &[entry(&[], "b", "x")]).is_none());
+
+        let mut meta2 = parent_meta(
+            "fk_user",
+            DependencyType::NestedObject,
+            Some(vec!["author".to_string()]),
+        );
+        meta2.is_union = true;
+        assert!(derive_parent_chain(&meta2, "user", &[entry(&[], "b", "x")]).is_none());
+    }
+
+    #[test]
+    fn two_level_composition_prepends_both_prefixes() {
+        // Child `user` already embedded at ["author"] within `post`; now `feed`
+        // embeds `post` at ["post"]. A user patch derived for post as
+        // (["author"], …) composes at feed as (["post","author"], …).
+        let feed_meta = parent_meta(
+            "fk_post",
+            DependencyType::NestedObject,
+            Some(vec!["post".to_string()]),
+        );
+        let post_chain = vec![entry(&["author"], "bio", "x")];
+        let derived = derive_parent_chain(&feed_meta, "post", &post_chain).unwrap();
+        assert_eq!(derived[0].0, vec!["post".to_string(), "author".to_string()]);
     }
 }

--- a/src/refresh/direct.rs
+++ b/src/refresh/direct.rs
@@ -1,0 +1,196 @@
+//! Flush-time direct patch application (issue #56).
+//!
+//! Consumes the transaction-local patch chains captured by the row trigger and
+//! applies them straight to `tv_<entity>` via `jsonb_smart_patch_*` — **zero**
+//! backing-view queries. Any pk whose tview row does not yet exist is reported
+//! back so the caller recomputes it (a patch can only update an existing row).
+
+use crate::catalog::TviewMeta;
+use crate::queue::patch::PatchEntry;
+use pgrx::datum::DatumWithOid;
+use pgrx::prelude::*;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+
+/// Apply one patch chain to a set of rows of a single entity.
+///
+/// Generates a grouped `UPDATE tv_<entity> SET data = <nested patch calls> WHERE
+/// pk = ANY($n) RETURNING pk`. Patch values are always bound as JSONB parameters
+/// — never interpolated. Returns the pks actually updated (from `RETURNING`); the
+/// caller diffs these against the input to find rows that must recompute.
+pub fn apply_direct_patch(
+    meta: &TviewMeta,
+    pks: &[i64],
+    chain: &[PatchEntry],
+) -> spi::Result<Vec<i64>> {
+    if pks.is_empty() || chain.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let tv_name = crate::utils::relname_from_oid(meta.tview_oid)?;
+    let pk_col = format!("pk_{}", meta.entity_name);
+    let patch_expr = build_direct_patch_expr(chain);
+    let pk_param = chain.len() + 1;
+
+    let sql = format!(
+        "UPDATE {tv_name} SET data = {patch_expr}, updated_at = now() \
+         WHERE {pk_col} = ANY(${pk_param}) RETURNING {pk_col}"
+    );
+
+    // Params: one JSONB per chain entry (in order), then the pk array.
+    // SAFETY: DatumWithOid wraps validated structured data (JSONB documents and a
+    // BIGINT[]) for SPI parameter passing.
+    let json_args: Vec<pgrx::JsonB> = chain
+        .iter()
+        .map(|(_, fields)| pgrx::JsonB(Value::Object(fields.clone())))
+        .collect();
+    let pk_vec = pks.to_vec();
+
+    Spi::connect(|client| {
+        let mut args: Vec<DatumWithOid> = Vec::with_capacity(chain.len() + 1);
+        for j in &json_args {
+            args.push(unsafe {
+                DatumWithOid::new(
+                    pgrx::JsonB(j.0.clone()),
+                    PgOid::BuiltIn(PgBuiltInOids::JSONBOID).value(),
+                )
+            });
+        }
+        args.push(unsafe {
+            DatumWithOid::new(
+                pk_vec.clone(),
+                PgOid::BuiltIn(PgBuiltInOids::INT8ARRAYOID).value(),
+            )
+        });
+
+        let rows = client.select(&sql, None, &args)?;
+        let mut updated = Vec::new();
+        for row in rows {
+            if let Some(pk) = row[1].value::<i64>()? {
+                updated.push(pk);
+            }
+        }
+        Ok(updated)
+    })
+}
+
+/// Apply all direct patches for one entity, grouping pks that share an identical
+/// chain into a single UPDATE (chunked by `pg_tviews.batch_size`). Increments the
+/// applied/fallback counters. Returns the pks that fell back (row not materialised)
+/// and must be recomputed by the caller.
+pub fn apply_entity_patches(
+    meta: &TviewMeta,
+    keyed_chains: Vec<(i64, Vec<PatchEntry>)>,
+) -> spi::Result<Vec<i64>> {
+    // Group pks by identical chain (canonical JSON form).
+    let mut groups: HashMap<String, (Vec<PatchEntry>, Vec<i64>)> = HashMap::new();
+    for (pk, chain) in keyed_chains {
+        let canonical = serde_json::to_string(&chain).unwrap_or_default();
+        let entry = groups
+            .entry(canonical)
+            .or_insert_with(|| (chain, Vec::new()));
+        entry.1.push(pk);
+    }
+
+    let batch = crate::config::batch_size();
+    let mut fallback = Vec::new();
+    for (chain, pks) in groups.into_values() {
+        for chunk in pks.chunks(batch) {
+            let updated = apply_direct_patch(meta, chunk, &chain)?;
+            let updated_set: HashSet<i64> = updated.iter().copied().collect();
+
+            crate::metrics::metrics_api::record_direct_patches_applied(updated.len() as u64);
+            for &pk in chunk {
+                if !updated_set.contains(&pk) {
+                    fallback.push(pk);
+                }
+            }
+        }
+    }
+
+    if !fallback.is_empty() {
+        crate::metrics::metrics_api::record_direct_patch_fallbacks(fallback.len() as u64);
+    }
+    Ok(fallback)
+}
+
+/// Build the nested `jsonb_smart_patch_*` expression for a chain, innermost first
+/// (the existing `data` column). Each entry contributes one call and one `$n`
+/// JSONB parameter:
+/// - empty prefix ⇒ `jsonb_smart_patch_scalar(expr, $n::jsonb)` (top-level merge),
+/// - non-empty prefix ⇒ `jsonb_smart_patch_nested(expr, $n::jsonb, ARRAY[...])`.
+fn build_direct_patch_expr(chain: &[PatchEntry]) -> String {
+    let mut expr = "data".to_string();
+    for (i, (prefix, _fields)) in chain.iter().enumerate() {
+        let param = i + 1;
+        if prefix.is_empty() {
+            expr = format!("jsonb_smart_patch_scalar({expr}, ${param}::jsonb)");
+        } else {
+            let path_literal = prefix
+                .iter()
+                .map(|seg| format!("'{}'", seg.replace('\'', "''")))
+                .collect::<Vec<_>>()
+                .join(", ");
+            expr =
+                format!("jsonb_smart_patch_nested({expr}, ${param}::jsonb, ARRAY[{path_literal}])");
+        }
+    }
+    expr
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Map;
+
+    fn entry(prefix: &[&str], k: &str, v: &str) -> PatchEntry {
+        let mut m = Map::new();
+        m.insert(k.to_string(), Value::String(v.to_string()));
+        (prefix.iter().map(|s| (*s).to_string()).collect(), m)
+    }
+
+    #[test]
+    fn top_level_chain_builds_scalar_merge() {
+        let chain = vec![entry(&[], "bio", "x")];
+        assert_eq!(
+            build_direct_patch_expr(&chain),
+            "jsonb_smart_patch_scalar(data, $1::jsonb)"
+        );
+    }
+
+    #[test]
+    fn nested_prefix_builds_nested_call() {
+        let chain = vec![entry(&["author"], "bio", "x")];
+        assert_eq!(
+            build_direct_patch_expr(&chain),
+            "jsonb_smart_patch_nested(data, $1::jsonb, ARRAY['author'])"
+        );
+    }
+
+    #[test]
+    fn two_level_prefix_lists_both_segments() {
+        let chain = vec![entry(&["post", "author"], "bio", "x")];
+        assert_eq!(
+            build_direct_patch_expr(&chain),
+            "jsonb_smart_patch_nested(data, $1::jsonb, ARRAY['post', 'author'])"
+        );
+    }
+
+    #[test]
+    fn mixed_chain_nests_calls_in_order() {
+        let chain = vec![entry(&[], "title", "t"), entry(&["author"], "bio", "b")];
+        assert_eq!(
+            build_direct_patch_expr(&chain),
+            "jsonb_smart_patch_nested(jsonb_smart_patch_scalar(data, $1::jsonb), $2::jsonb, ARRAY['author'])"
+        );
+    }
+
+    #[test]
+    fn single_quote_in_path_segment_is_escaped() {
+        let chain = vec![entry(&["we'ird"], "k", "v")];
+        assert_eq!(
+            build_direct_patch_expr(&chain),
+            "jsonb_smart_patch_nested(data, $1::jsonb, ARRAY['we''ird'])"
+        );
+    }
+}

--- a/src/refresh/main.rs
+++ b/src/refresh/main.rs
@@ -293,6 +293,10 @@ fn build_dedup_dml_components(col_names: &[String], key_col: &str) -> (String, S
 /// -- Returns: pk_post, fk_user, data JSONB
 /// ```
 fn recompute_view_row(meta: &TviewMeta, pk: i64) -> spi::Result<Option<ViewRow>> {
+    // Count the backing-view query (issue #56): the direct-patch fast path exists
+    // precisely to avoid reaching here for eligible changes.
+    crate::metrics::metrics_api::record_view_recomputes(1);
+
     let view_name = lookup_view_for_source(meta.view_oid)?;
     let pk_col = format!("pk_{}", meta.entity_name); // e.g. pk_post
 

--- a/src/refresh/mod.rs
+++ b/src/refresh/mod.rs
@@ -8,6 +8,7 @@ pub mod array_ops;
 pub mod main;
 
 pub mod bulk;
+pub mod direct;
 
 // Re-export main functions for backward compatibility
 pub use main::refresh_pk;

--- a/src/schema/direct_map.rs
+++ b/src/schema/direct_map.rs
@@ -1,0 +1,487 @@
+//! Direct-patch column→key extraction (issue #56).
+//!
+//! Extracts, from a TVIEW's SELECT statement, the set of base-table columns that
+//! map *identity-style* to top-level keys of the entity's own `data` JSONB object
+//! (e.g. `jsonb_build_object('bio', bio)` ⇒ `bio → bio`). These mappings let the
+//! row trigger build a JSONB patch straight from `NEW` without re-querying the
+//! backing view (the "direct-patch fast path").
+//!
+//! The extraction is deliberately **conservative**: anything it is unsure about is
+//! omitted. An omitted (or smaller) map only means fewer fast-path hits — never
+//! incorrect data, because the recompute path remains the single source of truth.
+
+use crate::schema::parser::{parse_select_columns_with_expressions, split_by_top_level_comma};
+use std::collections::HashMap;
+
+/// SQL keywords that can immediately follow the base table in a FROM clause,
+/// signalling that the table has no alias (`FROM tb_post WHERE …`).
+const FROM_KEYWORDS: &[&str] = &[
+    "where", "join", "left", "right", "inner", "outer", "full", "cross", "group", "order", "on",
+    "union", "limit", "offset", "having", "using", "natural", "as", "and", "or",
+];
+
+/// Extract identity-style `(base_column, jsonb_key)` pairs from the top-level
+/// `jsonb_build_object(...)` that produces the entity's `data` output column.
+///
+/// `base_table` is the entity's base table name (e.g. `"tb_post"`); its FROM-clause
+/// alias is resolved internally so `p.title` is accepted when the view says
+/// `FROM tb_post p`.
+///
+/// Only pairs whose value is a *bare* base-table column survive:
+/// - unqualified `col`,
+/// - `tb_<entity>.col` (base table referenced by name), or
+/// - `<alias>.col` (base table's FROM alias).
+///
+/// Everything else is rejected — omission is the fallback signal:
+/// - any expression (`first || ' ' || last`, casts, function calls, `CASE`, …),
+/// - columns qualified with another relation (`u.name`, `v_user.data`),
+/// - nested `jsonb_build_object` / `jsonb_agg` values (dependency machinery owns those),
+/// - duplicate keys or duplicate columns (ambiguous ⇒ recompute).
+#[must_use]
+pub fn extract_direct_column_map(select_sql: &str, base_table: &str) -> Vec<(String, String)> {
+    // 1. Isolate the `data` output column's full expression.
+    let Ok(columns) = parse_select_columns_with_expressions(select_sql) else {
+        return Vec::new();
+    };
+    let Some((_, data_expr)) = columns
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("data"))
+    else {
+        return Vec::new();
+    };
+
+    // 2. The expression must be a bare top-level jsonb_build_object(...) call.
+    let Some(args_str) = jsonb_build_object_args(data_expr) else {
+        return Vec::new();
+    };
+
+    // 3. Split the builder arguments into key/value pairs.
+    let parts = split_by_top_level_comma(args_str);
+    if parts.is_empty() || !parts.len().is_multiple_of(2) {
+        return Vec::new();
+    }
+
+    // 4. Resolve the base table's FROM-clause alias (if any).
+    let alias = resolve_base_alias(select_sql, base_table);
+
+    // 5. Classify each key/value pair.
+    let mut pairs: Vec<(String, String)> = Vec::new();
+    for pair in parts.chunks_exact(2) {
+        let (Some(key), Some(col)) = (
+            parse_key_literal(&pair[0]),
+            classify_direct_value(&pair[1], base_table, alias.as_deref()),
+        ) else {
+            continue;
+        };
+        pairs.push((col, key));
+    }
+
+    // 6. Drop ambiguous keys/columns (each must appear exactly once).
+    drop_ambiguous(&pairs)
+}
+
+/// If `expr` (leading-trimmed) begins with a `jsonb_build_object(` call, return the
+/// raw substring between its outermost matching parentheses. `None` otherwise —
+/// e.g. the data column is a subquery, a `COALESCE(...)` wrapper, or otherwise not
+/// a bare builder call (all of which fall back to recompute).
+fn jsonb_build_object_args(expr: &str) -> Option<&str> {
+    const FN_NAME: &str = "jsonb_build_object";
+    let trimmed = expr.trim_start();
+
+    let prefix = trimmed.get(..FN_NAME.len())?;
+    if !prefix.eq_ignore_ascii_case(FN_NAME) {
+        return None;
+    }
+    let after = trimmed[FN_NAME.len()..].trim_start();
+    if !after.starts_with('(') {
+        return None;
+    }
+
+    // Byte offset of the opening '(' within `trimmed` (ASCII: boundary-safe).
+    let open_idx = trimmed.len() - after.len();
+    let bytes = trimmed.as_bytes();
+    let mut depth: i32 = 0;
+    let mut in_squote = false;
+    let mut in_dquote = false;
+    let mut prev = 0u8;
+    let mut i = open_idx;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' if !in_dquote && prev != b'\\' => in_squote = !in_squote,
+            b'"' if !in_squote && prev != b'\\' => in_dquote = !in_dquote,
+            b'(' if !in_squote && !in_dquote => depth += 1,
+            b')' if !in_squote && !in_dquote => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(trimmed[open_idx + 1..i].trim());
+                }
+            }
+            _ => {}
+        }
+        prev = bytes[i];
+        i += 1;
+    }
+    None
+}
+
+/// Parse a single-quoted SQL string literal `'key'` into its unquoted text.
+///
+/// Returns `None` unless `s` is a plain string literal whose contents are a
+/// simple identifier-like token (letters, digits, underscore). Rejecting exotic
+/// keys keeps later `ARRAY['…']` path building free of quoting/escaping hazards
+/// (issue #56 security note) — such keys simply fall back to recompute.
+fn parse_key_literal(s: &str) -> Option<String> {
+    let inner = s.trim().strip_prefix('\'')?.strip_suffix('\'')?;
+    if inner.is_empty() || !is_simple_ident_chars(inner) {
+        return None;
+    }
+    Some(inner.to_string())
+}
+
+/// Classify a `jsonb_build_object` value expression. Returns `Some(base_column)`
+/// when the value is a bare base-table column reference; `None` otherwise.
+fn classify_direct_value(value: &str, base_table: &str, alias: Option<&str>) -> Option<String> {
+    let v = value.trim();
+    if v.is_empty() {
+        return None;
+    }
+
+    // Accept at most one qualifier segment: `col` or `qualifier.col`.
+    let mut segs = v.split('.');
+    let first = segs.next()?;
+    let (qualifier, col) = match segs.next() {
+        None => (None, first),
+        Some(second) => {
+            if segs.next().is_some() {
+                return None; // schema.table.col or deeper — reject
+            }
+            (Some(first), second)
+        }
+    };
+
+    if !is_simple_ident(col) {
+        return None;
+    }
+    if let Some(q) = qualifier {
+        if !is_simple_ident(q) {
+            return None;
+        }
+        let matches_base =
+            q.eq_ignore_ascii_case(base_table) || alias.is_some_and(|a| q.eq_ignore_ascii_case(a));
+        if !matches_base {
+            return None;
+        }
+    }
+    Some(col.to_string())
+}
+
+/// Resolve the FROM-clause alias of `base_table`, if the view assigns one:
+/// `FROM tb_post p` ⇒ `Some("p")`, `FROM tb_post AS p` ⇒ `Some("p")`,
+/// `FROM tb_post` ⇒ `None`.
+///
+/// Conservative: only the primary FROM table's alias is resolved, so a joined
+/// relation's alias is never mistaken for the base table's — accepting a joined
+/// alias would let a joined column masquerade as a base column and break
+/// byte-identity with the recompute path.
+fn resolve_base_alias(select_sql: &str, base_table: &str) -> Option<String> {
+    let lower = select_sql.to_lowercase();
+    let base_lower = base_table.to_lowercase();
+
+    // Find the first FROM (word-bounded) and the base table immediately after it.
+    let from_pos = find_word(&lower, "from", 0)?;
+    let rel_pos = find_word(&lower, &base_lower, from_pos + "from".len())?;
+    let after_rel = rel_pos + base_lower.len();
+
+    // Work on the original-case tail so the alias keeps its case.
+    let tail = select_sql.get(after_rel..)?.trim_start();
+
+    // Skip an optional AS keyword.
+    let tail = match tail.get(..2) {
+        Some(kw)
+            if kw.eq_ignore_ascii_case("as")
+                && tail[2..].starts_with(|c: char| c.is_whitespace()) =>
+        {
+            tail[2..].trim_start()
+        }
+        _ => tail,
+    };
+
+    // The alias is the leading identifier token.
+    let alias: String = tail
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect();
+    if alias.is_empty() {
+        return None;
+    }
+
+    // A SQL keyword here means the base table had no alias (`FROM tb_post WHERE …`).
+    if FROM_KEYWORDS.contains(&alias.to_lowercase().as_str()) {
+        return None;
+    }
+    Some(alias)
+}
+
+/// Keep only `(col, key)` pairs where both the column and the key appear exactly
+/// once across the whole map. A key claimed by two columns (`'x', a, 'x', b`) or a
+/// column mapped to two keys is ambiguous ⇒ dropped ⇒ that column recomputes.
+/// Insertion order is preserved.
+fn drop_ambiguous(pairs: &[(String, String)]) -> Vec<(String, String)> {
+    let mut key_counts: HashMap<&str, u32> = HashMap::new();
+    let mut col_counts: HashMap<&str, u32> = HashMap::new();
+    for (col, key) in pairs {
+        *key_counts.entry(key.as_str()).or_insert(0) += 1;
+        *col_counts.entry(col.as_str()).or_insert(0) += 1;
+    }
+    pairs
+        .iter()
+        .filter(|(col, key)| key_counts[key.as_str()] == 1 && col_counts[col.as_str()] == 1)
+        .cloned()
+        .collect()
+}
+
+/// A whole-word, case-insensitive search returning the byte offset of the match.
+/// `haystack_lower` and `needle_lower` must already be lowercased.
+fn find_word(haystack_lower: &str, needle_lower: &str, start: usize) -> Option<usize> {
+    if needle_lower.is_empty() {
+        return None;
+    }
+    let hay = haystack_lower.as_bytes();
+    let needle = needle_lower.as_bytes();
+    let nlen = needle.len();
+    let mut i = start;
+    while i + nlen <= hay.len() {
+        if &hay[i..i + nlen] == needle {
+            let before = i == 0 || !is_ident_byte(hay[i - 1]);
+            let after = i + nlen >= hay.len() || !is_ident_byte(hay[i + nlen]);
+            if before && after {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// `true` if `s` is a simple SQL identifier: leading letter/underscore, then
+/// letters/digits/underscores.
+fn is_simple_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    is_simple_ident_chars(s)
+}
+
+/// `true` if every character of `s` is a letter, digit, or underscore (non-empty).
+fn is_simple_ident_chars(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+const fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Convenience: run extraction and return an ordered `Vec` of `(col, key)`.
+    fn extract(sql: &str, base: &str) -> Vec<(String, String)> {
+        extract_direct_column_map(sql, base)
+    }
+
+    // ---- Cycle 1: happy path ---------------------------------------------
+
+    #[test]
+    fn extracts_bare_column_and_omits_nested_object() {
+        let sql = "SELECT pk_post, fk_user, \
+             jsonb_build_object('title', title, 'author', v_user.data) AS data \
+             FROM tb_post";
+        assert_eq!(
+            extract(sql, "tb_post"),
+            vec![("title".to_string(), "title".to_string())]
+        );
+    }
+
+    #[test]
+    fn extracts_alias_qualified_base_column() {
+        let sql = "SELECT pk_post, \
+             jsonb_build_object('title', p.title) AS data \
+             FROM tb_post p";
+        assert_eq!(
+            extract(sql, "tb_post"),
+            vec![("title".to_string(), "title".to_string())]
+        );
+    }
+
+    #[test]
+    fn extracts_alias_qualified_with_as_keyword() {
+        let sql = "SELECT pk_post, \
+             jsonb_build_object('title', p.title) AS data \
+             FROM tb_post AS p";
+        assert_eq!(
+            extract(sql, "tb_post"),
+            vec![("title".to_string(), "title".to_string())]
+        );
+    }
+
+    #[test]
+    fn extracts_base_table_qualified_column() {
+        let sql = "SELECT pk_post, \
+             jsonb_build_object('title', tb_post.title) AS data \
+             FROM tb_post";
+        assert_eq!(
+            extract(sql, "tb_post"),
+            vec![("title".to_string(), "title".to_string())]
+        );
+    }
+
+    #[test]
+    fn key_differs_from_column_name() {
+        let sql = "SELECT pk_post, \
+             jsonb_build_object('headline', title) AS data \
+             FROM tb_post";
+        assert_eq!(
+            extract(sql, "tb_post"),
+            vec![("title".to_string(), "headline".to_string())]
+        );
+    }
+
+    #[test]
+    fn extracts_multiple_bare_columns_in_order() {
+        let sql = "SELECT pk_user, \
+             jsonb_build_object('name', name, 'bio', bio, 'age', age) AS data \
+             FROM tb_user";
+        assert_eq!(
+            extract(sql, "tb_user"),
+            vec![
+                ("name".to_string(), "name".to_string()),
+                ("bio".to_string(), "bio".to_string()),
+                ("age".to_string(), "age".to_string()),
+            ]
+        );
+    }
+
+    // ---- Cycle 2: rejection cases ----------------------------------------
+
+    #[test]
+    fn rejects_concatenation_expression() {
+        let sql = "SELECT pk_user, \
+             jsonb_build_object('full_name', first_name || ' ' || last_name, 'bio', bio) AS data \
+             FROM tb_user";
+        // Only the bare `bio` survives; the concat expression is omitted.
+        assert_eq!(
+            extract(sql, "tb_user"),
+            vec![("bio".to_string(), "bio".to_string())]
+        );
+    }
+
+    #[test]
+    fn rejects_cast_expression() {
+        let sql = "SELECT pk_user, \
+             jsonb_build_object('n', n::text, 'bio', bio) AS data \
+             FROM tb_user";
+        assert_eq!(
+            extract(sql, "tb_user"),
+            vec![("bio".to_string(), "bio".to_string())]
+        );
+    }
+
+    #[test]
+    fn rejects_other_relation_qualifier() {
+        let sql = "SELECT pk_post, \
+             jsonb_build_object('uname', u.name, 'title', title) AS data \
+             FROM tb_post p JOIN tb_user u ON u.pk_user = p.fk_user";
+        // `u.name` is a joined relation → omitted; base `title` survives.
+        assert_eq!(
+            extract(sql, "tb_post"),
+            vec![("title".to_string(), "title".to_string())]
+        );
+    }
+
+    #[test]
+    fn rejects_jsonb_agg_value() {
+        let sql = "SELECT pk_user, \
+             jsonb_build_object('name', name, 'posts', jsonb_agg(v_post.data)) AS data \
+             FROM tb_user LEFT JOIN v_post ON v_post.fk_user = pk_user GROUP BY pk_user, name";
+        assert_eq!(
+            extract(sql, "tb_user"),
+            vec![("name".to_string(), "name".to_string())]
+        );
+    }
+
+    #[test]
+    fn rejects_nested_jsonb_build_object_value() {
+        let sql = "SELECT pk_post, \
+             jsonb_build_object('title', title, 'meta', jsonb_build_object('x', 1)) AS data \
+             FROM tb_post";
+        assert_eq!(
+            extract(sql, "tb_post"),
+            vec![("title".to_string(), "title".to_string())]
+        );
+    }
+
+    #[test]
+    fn duplicate_key_drops_both() {
+        let sql = "SELECT pk_post, \
+             jsonb_build_object('x', a, 'x', b, 'title', title) AS data \
+             FROM tb_post";
+        // Both `x` mappings are ambiguous and dropped; only `title` remains.
+        assert_eq!(
+            extract(sql, "tb_post"),
+            vec![("title".to_string(), "title".to_string())]
+        );
+    }
+
+    #[test]
+    fn duplicate_column_drops_both() {
+        // Same column mapped to two keys — the col→key map can't represent this
+        // faithfully, so both are dropped (recompute).
+        let sql = "SELECT pk_post, \
+             jsonb_build_object('a', title, 'b', title, 'body', body) AS data \
+             FROM tb_post";
+        assert_eq!(
+            extract(sql, "tb_post"),
+            vec![("body".to_string(), "body".to_string())]
+        );
+    }
+
+    #[test]
+    fn no_jsonb_build_object_yields_empty_map() {
+        let sql = "SELECT pk_post, sub.data AS data FROM tb_post \
+             JOIN (SELECT pk_post, data FROM other) sub USING (pk_post)";
+        assert!(extract(sql, "tb_post").is_empty());
+    }
+
+    #[test]
+    fn coalesce_wrapped_data_yields_empty_map() {
+        let sql = "SELECT pk_post, \
+             COALESCE(jsonb_build_object('title', title), '{}'::jsonb) AS data \
+             FROM tb_post";
+        // Not a bare jsonb_build_object() call → conservatively empty.
+        assert!(extract(sql, "tb_post").is_empty());
+    }
+
+    #[test]
+    fn missing_data_column_yields_empty_map() {
+        let sql = "SELECT pk_post, title FROM tb_post";
+        assert!(extract(sql, "tb_post").is_empty());
+    }
+
+    #[test]
+    fn rejects_quoted_weird_key() {
+        // Key with an embedded quote is not a simple identifier ⇒ omitted,
+        // keeping ARRAY['…'] path building safe.
+        let sql = "SELECT pk_post, \
+             jsonb_build_object('title', title) AS data FROM tb_post";
+        // Sanity: the safe key is kept.
+        assert_eq!(
+            extract(sql, "tb_post"),
+            vec![("title".to_string(), "title".to_string())]
+        );
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -26,6 +26,7 @@
 //! ```
 
 pub mod analyzer;
+pub mod direct_map;
 pub mod inference;
 pub mod parser;
 pub mod types;

--- a/src/schema/parser.rs
+++ b/src/schema/parser.rs
@@ -594,7 +594,7 @@ fn extract_columns_with_expressions_regex(sql: &str) -> Result<Vec<(String, Stri
 }
 
 /// Split string by commas, but only at top level (outside parentheses and quotes)
-fn split_by_top_level_comma(s: &str) -> Vec<String> {
+pub(crate) fn split_by_top_level_comma(s: &str) -> Vec<String> {
     let mut parts = Vec::new();
     let mut current = String::new();
     let mut paren_depth: i32 = 0;

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -1,6 +1,10 @@
 use crate::catalog::entity_for_table;
-use crate::queue::{enqueue_refresh, enqueue_refresh_bulk, enqueue_refresh_dedup};
+use crate::queue::cache::CachedEntityInfo;
+use crate::queue::{
+    enqueue_refresh, enqueue_refresh_bulk, enqueue_refresh_dedup, enqueue_refresh_patched,
+};
 use crate::utils::{IntExtraction, quote_identifier, tuple_get_i64};
+use pgrx::PgTupleDesc;
 use pgrx::prelude::*;
 /// Trigger Handler: Change Detection and Queue Management
 ///
@@ -152,7 +156,17 @@ fn pg_tview_trigger_handler<'a>(
                         return Ok(None);
                     }
                 };
-                enqueue_refresh(entity, pk_value);
+                // Issue #56: on an eligible row-level UPDATE, capture a direct patch
+                // from NEW and enqueue it alongside the key (the counter is bumped
+                // once per fresh key inside enqueue_refresh_patched). Anything
+                // ineligible (or any capture miss) falls through to the plain
+                // enqueue, which poisons the key so it recomputes — the universal,
+                // always-correct path.
+                if let Some(fields) = try_capture_direct_patch(trigger, &entity_info) {
+                    enqueue_refresh_patched(entity, pk_value, fields);
+                } else {
+                    enqueue_refresh(entity, pk_value);
+                }
             }
             return Ok(None);
         }
@@ -262,6 +276,199 @@ fn follow_cascade_path(
     }
 
     Ok(())
+}
+
+// ── Issue #56: direct-patch capture ──────────────────────────────────────────
+
+unsafe extern "C" {
+    /// `PostgreSQL`'s `datumIsEqual` (`src/backend/utils/adt/datum.c`) — exported
+    /// by the backend but absent from the pgrx bindings; resolved at `.so` load
+    /// time like every other `pg_sys` symbol. Compares datums for physical equality.
+    #[link_name = "datumIsEqual"]
+    fn datum_is_equal(
+        value1: pg_sys::Datum,
+        value2: pg_sys::Datum,
+        typ_by_val: bool,
+        typ_len: i32,
+    ) -> bool;
+}
+
+/// Try to capture a direct patch for an eligible row-level UPDATE (issue #56).
+///
+/// Returns `Some(fields)` — a `key → value` JSONB map ready to merge into the
+/// entity's own `data` — only when **every** eligibility condition holds; `None`
+/// (fall back to recompute) otherwise. Pure in-memory: cached `EntityInfo`, a raw
+/// datum diff, and typed value extraction — no SPI.
+fn try_capture_direct_patch(
+    trigger: &PgTrigger,
+    entity_info: &CachedEntityInfo,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    use std::collections::HashSet;
+
+    // Entity-level gates (cheapest first).
+    if !crate::config::direct_patch_enabled()
+        || entity_info.direct_map.is_empty()
+        || entity_info.distinct_on_key.is_some()
+        || entity_info.is_union
+    {
+        return None;
+    }
+    if !crate::lifecycle::check_jsonb_delta_available() {
+        return None;
+    }
+
+    // Full-tuple diff — `None` unless this is a row-level UPDATE (OLD and NEW both
+    // present). No changed columns ⇒ nothing to patch (let the caller plain-enqueue).
+    let changed = changed_columns(trigger)?;
+    if changed.is_empty() {
+        return None;
+    }
+
+    // Eligibility: every changed column must feed the entity's own `data` via the
+    // direct map, and none may be a membership/identity/projected column that a
+    // data-only patch would leave stale.
+    let pk_col = format!("pk_{}", entity_info.name);
+    let fk_set: HashSet<&str> = entity_info.fk_columns.iter().map(String::as_str).collect();
+    let uuid_fk_set: HashSet<&str> = entity_info
+        .uuid_fk_columns
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let output_set: HashSet<&str> = entity_info
+        .output_columns
+        .iter()
+        .map(String::as_str)
+        .collect();
+
+    for col in &changed {
+        if col == &pk_col
+            || fk_set.contains(col.as_str())
+            || uuid_fk_set.contains(col.as_str())
+            || output_set.contains(col.as_str())
+            || !entity_info.direct_map.contains_key(col.as_str())
+        {
+            return None;
+        }
+    }
+
+    // Capture NEW's value for each changed column with the type whitelist.
+    let new_tuple = trigger.new()?;
+    let mut fields = serde_json::Map::with_capacity(changed.len());
+    for col in &changed {
+        let key = entity_info.direct_map.get(col.as_str())?;
+        let value = capture_value(&new_tuple, col)?;
+        fields.insert(key.clone(), value);
+    }
+    Some(fields)
+}
+
+/// Diff OLD vs NEW over **all** columns of the changed row. Returns the names of
+/// columns whose stored value changed, or `None` when this is not a row-level
+/// UPDATE (either OLD or NEW absent).
+///
+/// Type-agnostic: compares raw datums via `datumIsEqual` over the relation's tuple
+/// descriptor, so it detects changes to *unmapped* columns (filter columns,
+/// computed-field inputs) without knowing their types. A false "changed" (e.g. an
+/// equal-but-differently-TOASTed varlena) is safe — it only forces a recompute.
+fn changed_columns(trigger: &PgTrigger) -> Option<Vec<String>> {
+    // SAFETY: inside a row-level AFTER trigger the `TriggerData` and its relation
+    // are valid for the call; `tg_trigtuple`/`tg_newtuple` are the OLD/NEW heap
+    // tuples and `rd_att` the matching tuple descriptor. `heap_getattr` reads a
+    // single attribute; `datum_is_equal` performs a physical (non-detoasting)
+    // comparison — never dereferencing beyond the datum itself.
+    unsafe {
+        let td: &pg_sys::TriggerData = trigger.trigger_data();
+        let old_tuple = td.tg_trigtuple;
+        let new_tuple = td.tg_newtuple;
+        if old_tuple.is_null() || new_tuple.is_null() {
+            return None; // INSERT or DELETE — a membership change, not a patch
+        }
+        let rel = td.tg_relation;
+        if rel.is_null() {
+            return None;
+        }
+        let tupdesc_ptr = (*rel).rd_att;
+        if tupdesc_ptr.is_null() {
+            return None;
+        }
+
+        let tupdesc = PgTupleDesc::from_pg_unchecked(tupdesc_ptr);
+        let mut changed = Vec::new();
+        for i in 0..tupdesc.len() {
+            let Some(att) = tupdesc.get(i) else { continue };
+            if att.attisdropped {
+                continue;
+            }
+            let attnum = i32::try_from(i + 1).ok()?;
+            let mut old_isnull = false;
+            let mut new_isnull = false;
+            let old_datum = pg_sys::heap_getattr(old_tuple, attnum, tupdesc_ptr, &mut old_isnull);
+            let new_datum = pg_sys::heap_getattr(new_tuple, attnum, tupdesc_ptr, &mut new_isnull);
+
+            let differs = if old_isnull != new_isnull {
+                true
+            } else if old_isnull {
+                false // both NULL
+            } else {
+                !datum_is_equal(old_datum, new_datum, att.attbyval, i32::from(att.attlen))
+            };
+            if differs {
+                changed.push(att.name().to_string());
+            }
+        }
+        Some(changed)
+    }
+}
+
+/// Extract NEW's value for `col` as a `serde_json::Value` using the type whitelist
+/// (issue #56). The whitelist matches `PostgreSQL`'s own `to_jsonb` output
+/// byte-for-byte; any other type (float, numeric, timestamp, array, …) yields
+/// `None`, forcing a recompute. SQL NULL becomes `Value::Null`.
+fn capture_value(
+    tuple: &PgHeapTuple<'_, AllocatedByPostgres>,
+    col: &str,
+) -> Option<serde_json::Value> {
+    use serde_json::Value;
+
+    // Each arm: Ok(Some) → value, Ok(None) → SQL NULL, Err → wrong type, try next.
+    match tuple.get_by_name::<String>(col) {
+        Ok(Some(v)) => return Some(Value::String(v)),
+        Ok(None) => return Some(Value::Null),
+        Err(_) => {}
+    }
+    match tuple.get_by_name::<bool>(col) {
+        Ok(Some(v)) => return Some(Value::Bool(v)),
+        Ok(None) => return Some(Value::Null),
+        Err(_) => {}
+    }
+    match tuple.get_by_name::<i64>(col) {
+        Ok(Some(v)) => return Some(Value::Number(v.into())),
+        Ok(None) => return Some(Value::Null),
+        Err(_) => {}
+    }
+    match tuple.get_by_name::<i32>(col) {
+        Ok(Some(v)) => return Some(Value::Number(v.into())),
+        Ok(None) => return Some(Value::Null),
+        Err(_) => {}
+    }
+    match tuple.get_by_name::<i16>(col) {
+        Ok(Some(v)) => return Some(Value::Number(v.into())),
+        Ok(None) => return Some(Value::Null),
+        Err(_) => {}
+    }
+    // UUID → canonical lowercase string, matching uuid::text / to_jsonb(uuid).
+    match tuple.get_by_name::<pgrx::Uuid>(col) {
+        Ok(Some(v)) => return Some(Value::String(v.to_string())),
+        Ok(None) => return Some(Value::Null),
+        Err(_) => {}
+    }
+    // JSONB → passthrough of the parsed value.
+    match tuple.get_by_name::<pgrx::JsonB>(col) {
+        Ok(Some(v)) => return Some(v.0),
+        Ok(None) => return Some(Value::Null),
+        Err(_) => {}
+    }
+    None
 }
 
 /// Statement-level AFTER trigger that flushes the refresh queue.

--- a/test/sql/real_benchmark/results/issue_56_scalar_cascade_fanout.md
+++ b/test/sql/real_benchmark/results/issue_56_scalar_cascade_fanout.md
@@ -1,0 +1,40 @@
+# Issue #56 — `scalar_cascade_fanout` results
+
+Single-field author update (`UPDATE tb_user SET bio = …`) with a wide nested-parent
+fan-out (1 author → N posts, each embedding `author` as a nested object). The
+direct-patch fast path OFF (recompute baseline) vs ON.
+
+Harness: `test/sql/real_benchmark/scalar_cascade_fanout.sh` — a server-side plpgsql
+loop (one statement per iteration, so the per-statement flush still fires),
+counters read in the same session.
+
+Machine: local dev, PostgreSQL 18.1 (pgrx cluster, port 28818), debug build.
+
+| fan-out | iters | config | writes/s | view recomputes | patches applied |
+|---:|---:|---|---:|---:|---:|
+| 60  | 2000 | GUC off | 35 | 122,000 | 0 |
+| 60  | 2000 | GUC on  | 48 | **0** | 122,000 |
+| 300 | 800  | GUC off | 16 | 240,800 | 0 |
+| 300 | 800  | GUC on  | 21 | **0** | 240,800 |
+
+**Speedup (on/off): ~1.3–1.4×.** The decisive result is the recompute count:
+`122,000 → 0` (and `240,800 → 0`) — the fast path issues **zero backing-view
+queries**, counter-proven, while the baseline recomputes every fan-out row.
+
+## Why the local wall-clock ratio is modest (not the issue's ~76×)
+
+The issue's ~89 → thousands figure was measured against a **per-row** recompute
+baseline. Since then, issue #48 gave the recompute path a **bulk** upsert
+(`refresh_bulk`: one `INSERT … SELECT … ON CONFLICT` for the whole fan-out), so
+today's baseline is already efficient. The direct patch replaces that one bulk
+`INSERT…SELECT` (JOIN + `jsonb_build_object` per row) with one grouped
+`UPDATE … jsonb_smart_patch_nested` (path-merge per row) — both O(fan-out), so the
+gain is the per-row constant (JOIN + full-document rebuild eliminated), plus the
+fixed per-update flush overhead (trigger, topological sort, parent discovery) that
+both configs pay equally and which dilutes the ratio at this scale.
+
+The wall-clock win grows with **document/JOIN complexity** (heavier
+`jsonb_build_object` + more joined dimensions ⇒ recompute gets more expensive while
+the patch stays a path-merge) and under write contention (fewer/no reads of the
+backing relations). No performance bug was found: the fast path does one grouped
+UPDATE per entity, loads metadata once per entity (cached), and adds no per-key SPI.

--- a/test/sql/real_benchmark/scalar_cascade_fanout.sh
+++ b/test/sql/real_benchmark/scalar_cascade_fanout.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Issue #56 benchmark: single-field update with a wide nested-parent fan-out.
+#
+# Models the issue's motivating shape — 1 author, N posts each embedding the
+# author as a nested object (tv_post.data->'author') — and times
+# `UPDATE tb_user SET bio = 'bio-'||i` (each its own statement) with the
+# direct-patch fast path OFF (today's recompute baseline) vs ON.
+#
+# The timed loop runs SERVER-SIDE (a plpgsql loop, one statement per iteration so
+# the per-statement flush trigger still fires) to isolate the refresh cost from
+# client round-trip overhead. Counters are read in the SAME session (they are
+# per-backend thread-local) to prove the fast path did zero backing-view
+# recomputes. Absolute throughput is machine-specific; the RATIO is the portable
+# result.
+#
+# Usage:
+#   PGHOST=localhost PGPORT=28818 PGUSER=postgres ./scalar_cascade_fanout.sh [FANOUT] [ITERS]
+
+set -u
+export PGHOST="${PGHOST:-localhost}" PGPORT="${PGPORT:-28818}" PGUSER="${PGUSER:-postgres}"
+FANOUT="${1:-60}"      # posts per author
+ITERS="${2:-2000}"     # timed single-field updates per configuration
+DB="pg_tviews_bench_56_$$"
+PSQL="psql -X -v ON_ERROR_STOP=1 -q -t -A"
+
+cleanup() { psql -X -q -d postgres -c "DROP DATABASE IF EXISTS $DB" >/dev/null 2>&1; }
+trap cleanup EXIT
+
+psql -X -q -d postgres -c "DROP DATABASE IF EXISTS $DB" >/dev/null 2>&1
+psql -X -q -d postgres -c "CREATE DATABASE $DB" >/dev/null 2>&1
+
+psql -X -q -v ON_ERROR_STOP=1 -d "$DB" >/dev/null <<SQL
+SET client_min_messages TO ERROR;
+CREATE EXTENSION jsonb_delta;
+CREATE EXTENSION pg_tviews;
+CREATE TABLE tb_user (pk_user INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                      id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE, name TEXT, bio TEXT);
+CREATE TABLE tb_post (pk_post INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                      id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+                      fk_user INT REFERENCES tb_user(pk_user), title TEXT);
+INSERT INTO tb_user (name, bio) VALUES ('Author', 'bio-0');
+INSERT INTO tb_post (fk_user, title)
+     SELECT 1, 'post-'||g FROM generate_series(1, $FANOUT) g;
+SELECT pg_tviews_create('tv_user', \$t\$
+    SELECT pk_user, id, jsonb_build_object('name', name, 'bio', bio) AS data FROM tb_user \$t\$);
+SELECT pg_tviews_create('tv_post', \$t\$
+    SELECT tb_post.pk_post, tb_post.id, tb_post.fk_user,
+           jsonb_build_object('title', tb_post.title, 'author', v_user.data) AS data
+    FROM tb_post LEFT JOIN v_user ON v_user.pk_user = tb_post.fk_user \$t\$);
+SQL
+
+run_config() {  # $1 = on|off  -> "writes_per_s recomputes patches_applied"
+  local guc="$1"
+  $PSQL -d "$DB" <<SQL | grep '^RESULT' | tail -1 | sed 's/^RESULT|//' | tr '|' ' '
+SET client_min_messages TO ERROR;
+SET pg_tviews.direct_patch_enabled = $guc;
+UPDATE tb_user SET bio = 'warm' WHERE pk_user = 1;
+SELECT (pg_tviews_queue_stats()->>'view_recomputes')::bigint AS rc0,
+       (pg_tviews_queue_stats()->>'direct_patches_applied')::bigint AS ap0 \gset
+SELECT extract(epoch FROM clock_timestamp()) AS t0 \gset
+DO \$b\$ BEGIN
+  FOR i IN 1..$ITERS LOOP
+    UPDATE tb_user SET bio = 'bio-'||i WHERE pk_user = 1;
+  END LOOP;
+END \$b\$;
+SELECT extract(epoch FROM clock_timestamp()) AS t1 \gset
+SELECT 'RESULT|' || round($ITERS / (:t1 - :t0))::text
+       || '|' || ((pg_tviews_queue_stats()->>'view_recomputes')::bigint - :rc0)::text
+       || '|' || ((pg_tviews_queue_stats()->>'direct_patches_applied')::bigint - :ap0)::text;
+SQL
+}
+
+echo "== issue #56 scalar_cascade_fanout =="
+echo "server: $(psql -X -tAc 'SHOW server_version' | tr -d ' ')  fan-out: $FANOUT posts  iters: $ITERS"
+read -r off_wps off_rc off_ap < <(run_config off)
+read -r on_wps  on_rc  on_ap  < <(run_config on)
+ratio=$(awk "BEGIN{printf \"%.1f\", $on_wps/$off_wps}")
+
+printf "%-20s %12s %14s %16s\n" "config" "writes/s" "recomputes" "patches_applied"
+printf "%-20s %12s %14s %16s\n" "GUC off (baseline)" "$off_wps" "$off_rc" "$off_ap"
+printf "%-20s %12s %14s %16s\n" "GUC on (fast path)" "$on_wps" "$on_rc" "$on_ap"
+echo "speedup (on/off): ${ratio}x   (each update fans out to $FANOUT posts)"

--- a/test/sql/regress_issue_56_capture.sql
+++ b/test/sql/regress_issue_56_capture.sql
@@ -1,0 +1,122 @@
+-- Regression test for issue #56 (Phase 2): trigger diff + patch capture.
+--
+-- The row trigger captures a direct patch only for an eligible single-row UPDATE
+-- (every changed column maps identity-style into the entity's own `data`, no
+-- FK/PK/projected-column change). Observed via the session-cumulative
+-- `direct_patch_captured` counter in pg_tviews_queue_stats(). Patches are captured
+-- but NOT yet applied here (Phase 3) — the recompute path still produces the data.
+--
+--   psql -v ON_ERROR_STOP=1 -f test/sql/regress_issue_56_capture.sql
+
+\set ON_ERROR_STOP on
+SET client_min_messages TO WARNING;
+
+DROP EXTENSION IF EXISTS pg_tviews CASCADE;
+DROP EXTENSION IF EXISTS jsonb_delta CASCADE;
+CREATE EXTENSION jsonb_delta;
+CREATE EXTENSION pg_tviews;
+
+DROP TABLE IF EXISTS tv_post CASCADE;
+DROP VIEW  IF EXISTS v_post CASCADE;
+DROP TABLE IF EXISTS tv_user CASCADE;
+DROP VIEW  IF EXISTS v_user CASCADE;
+DROP TABLE IF EXISTS tb_post CASCADE;
+DROP TABLE IF EXISTS tb_user CASCADE;
+
+CREATE TABLE tb_user (
+    pk_user INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id      UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    name    TEXT,
+    bio     TEXT,
+    status  TEXT          -- unmapped base column (not in data, not projected)
+);
+CREATE TABLE tb_post (
+    pk_post INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id      UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    fk_user INTEGER REFERENCES tb_user(pk_user),
+    title   TEXT
+);
+INSERT INTO tb_user (name, bio, status) VALUES ('Alice', 'hello', 'active'), ('Bob', 'hi', 'active');
+INSERT INTO tb_post (fk_user, title) VALUES (1, 'Original');
+
+SELECT pg_tviews_create('tv_user', $TVIEW$
+    SELECT pk_user, id, jsonb_build_object('name', name, 'bio', bio) AS data
+    FROM tb_user
+$TVIEW$);
+SELECT pg_tviews_create('tv_post', $TVIEW$
+    SELECT tb_post.pk_post, tb_post.id, tb_post.fk_user,
+           jsonb_build_object('title', tb_post.title, 'author', v_user.data) AS data
+    FROM tb_post LEFT JOIN v_user ON v_user.pk_user = tb_post.fk_user
+$TVIEW$);
+
+-- Cycle 3: the kill-switch GUC exists and defaults to on.
+DO $$ BEGIN
+  IF current_setting('pg_tviews.direct_patch_enabled') <> 'on' THEN
+    RAISE EXCEPTION '#56 FAIL: direct_patch_enabled default is % (expected on)',
+      current_setting('pg_tviews.direct_patch_enabled');
+  END IF;
+END $$;
+
+-- Delta-assertion helper over the session-cumulative capture counter.
+CREATE TEMP TABLE _dp(prev bigint);
+INSERT INTO _dp VALUES ((pg_tviews_queue_stats()->>'direct_patch_captured')::bigint);
+
+CREATE FUNCTION _dp_assert(expected bigint, label text) RETURNS void LANGUAGE plpgsql AS $$
+DECLARE cur bigint; prv bigint;
+BEGIN
+  cur := (pg_tviews_queue_stats()->>'direct_patch_captured')::bigint;
+  SELECT prev INTO prv FROM _dp;
+  IF cur - prv <> expected THEN
+    RAISE EXCEPTION '#56 capture FAIL [%]: expected delta %, got % (prev=%, cur=%)',
+      label, expected, cur - prv, prv, cur;
+  END IF;
+  UPDATE _dp SET prev = cur;
+END $$;
+
+-- (1) eligible single mapped column ⇒ captured.
+UPDATE tb_user SET bio = 'b1' WHERE pk_user = 1;
+SELECT _dp_assert(1, 'eligible single column (bio)');
+
+-- (2) eligible single mapped column (name) ⇒ captured.
+UPDATE tb_user SET name = 'Alice2' WHERE pk_user = 1;
+SELECT _dp_assert(1, 'eligible single column (name)');
+
+-- (3) eligible multi-column (both mapped) in one row ⇒ one capture.
+UPDATE tb_user SET bio = 'b2', name = 'Alice3' WHERE pk_user = 1;
+SELECT _dp_assert(1, 'eligible multi-column (bio+name)');
+
+-- (4) FK-column change ⇒ NOT captured (membership change).
+UPDATE tb_post SET fk_user = 2 WHERE pk_post = 1;
+SELECT _dp_assert(0, 'fk-column update');
+
+-- (5) mixed eligible + ineligible in one UPDATE ⇒ NOT captured.
+UPDATE tb_post SET title = 'T2', fk_user = 1 WHERE pk_post = 1;
+SELECT _dp_assert(0, 'mixed eligible+fk update');
+
+-- (6) unmapped base column change ⇒ NOT captured (could be a filter/computed input).
+UPDATE tb_user SET status = 'inactive' WHERE pk_user = 1;
+SELECT _dp_assert(0, 'unmapped column (status)');
+
+-- (7) INSERT ⇒ NOT captured (no OLD row; membership change).
+INSERT INTO tb_user (name, bio, status) VALUES ('Carol', 'yo', 'active');
+SELECT _dp_assert(0, 'insert');
+
+-- (8) DELETE ⇒ NOT captured.
+DELETE FROM tb_user WHERE name = 'Carol';
+SELECT _dp_assert(0, 'delete');
+
+-- (9) GUC off ⇒ eligible UPDATE NOT captured (kill-switch honoured at capture time).
+SET pg_tviews.direct_patch_enabled = off;
+UPDATE tb_user SET bio = 'b3' WHERE pk_user = 1;
+SELECT _dp_assert(0, 'guc off suppresses capture');
+SET pg_tviews.direct_patch_enabled = on;
+
+-- Sanity: recompute path still produces correct data in Phase 2 (patches unused).
+DO $$ BEGIN
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1) <> 'b3' THEN
+    RAISE EXCEPTION '#56 FAIL: tv_user.bio not refreshed by recompute (got %)',
+      (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1);
+  END IF;
+END $$;
+
+SELECT 'issue #56 capture: PASS' AS result;

--- a/test/sql/regress_issue_56_cascade.sql
+++ b/test/sql/regress_issue_56_cascade.sql
@@ -1,0 +1,199 @@
+-- Regression test for issue #56 (Phase 4): cascade patch propagation to parents.
+--
+-- The headline win. A patched child entity embedded in parents via nested_object
+-- dependencies propagates a DERIVED patch (child fields at the dependency path) —
+-- the whole fan-out runs as grouped jsonb_smart_patch_nested UPDATEs with zero view
+-- queries. Covers one-level, two-level, nested-patch preserves sibling array data,
+-- byte-identity vs a forced recompute, and child-fallback → parent recompute.
+--
+--   psql -v ON_ERROR_STOP=1 -f test/sql/regress_issue_56_cascade.sql
+
+\set ON_ERROR_STOP on
+SET client_min_messages TO WARNING;
+
+DROP EXTENSION IF EXISTS pg_tviews CASCADE;
+DROP EXTENSION IF EXISTS jsonb_delta CASCADE;
+CREATE EXTENSION jsonb_delta;
+CREATE EXTENSION pg_tviews;
+
+DROP TABLE IF EXISTS tv_feed CASCADE;    DROP VIEW IF EXISTS v_feed CASCADE;
+DROP TABLE IF EXISTS tv_post CASCADE;    DROP VIEW IF EXISTS v_post CASCADE;
+DROP TABLE IF EXISTS tv_user CASCADE;    DROP VIEW IF EXISTS v_user CASCADE;
+DROP TABLE IF EXISTS tb_feed CASCADE;
+DROP TABLE IF EXISTS tb_comment CASCADE;
+DROP TABLE IF EXISTS tb_post CASCADE;
+DROP TABLE IF EXISTS tb_user CASCADE;
+
+CREATE TABLE tb_user (
+    pk_user INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE, name TEXT, bio TEXT
+);
+CREATE TABLE tb_post (
+    pk_post INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    fk_user INTEGER REFERENCES tb_user(pk_user), title TEXT
+);
+CREATE TABLE tb_comment (
+    pk_comment INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    fk_post INTEGER REFERENCES tb_post(pk_post), body TEXT
+);
+CREATE TABLE tb_feed (
+    pk_feed INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    fk_post INTEGER REFERENCES tb_post(pk_post), label TEXT
+);
+
+-- A second user (with no posts) keeps tv_user non-empty when Alice's row is
+-- deleted in Cycle 4, so the crash-recovery truncation path stays dormant and the
+-- genuine per-row fallback is exercised.
+INSERT INTO tb_user (name, bio) VALUES ('Alice', 'author-bio'), ('Zoe', 'zoe-bio');
+INSERT INTO tb_post (fk_user, title) VALUES (1, 'P1'), (1, 'P2'), (1, 'P3');
+INSERT INTO tb_comment (fk_post, body) VALUES (1, 'c1'), (1, 'c2'), (2, 'c3');
+INSERT INTO tb_feed (fk_post, label) VALUES (1, 'F1'), (2, 'F2'), (3, 'F3');
+
+SELECT pg_tviews_create('tv_user', $TVIEW$
+    SELECT pk_user, id, jsonb_build_object('name', name, 'bio', bio) AS data
+    FROM tb_user
+$TVIEW$);
+-- Post embeds its author (nested_object) AND aggregates its comments (array).
+SELECT pg_tviews_create('tv_post', $TVIEW$
+    SELECT tb_post.pk_post, tb_post.id, tb_post.fk_user,
+           jsonb_build_object(
+               'title', tb_post.title,
+               'author', v_user.data,
+               'comments', COALESCE(jsonb_agg(
+                   jsonb_build_object('body', c.body) ORDER BY c.pk_comment)
+                   FILTER (WHERE c.pk_comment IS NOT NULL), '[]'::jsonb)
+           ) AS data
+    FROM tb_post
+    LEFT JOIN v_user ON v_user.pk_user = tb_post.fk_user
+    LEFT JOIN tb_comment c ON c.fk_post = tb_post.pk_post
+    GROUP BY tb_post.pk_post, tb_post.id, tb_post.fk_user, tb_post.title, v_user.data
+$TVIEW$);
+-- Feed embeds its post (nested_object) — two levels above user.
+SELECT pg_tviews_create('tv_feed', $TVIEW$
+    SELECT tb_feed.pk_feed, tb_feed.id, tb_feed.fk_post,
+           jsonb_build_object('label', tb_feed.label, 'post', v_post.data) AS data
+    FROM tb_feed LEFT JOIN v_post ON v_post.pk_post = tb_feed.fk_post
+$TVIEW$);
+
+-- Precondition: post is classified nested_object on the author dependency.
+DO $$ BEGIN
+  IF NOT (SELECT dependency_types @> ARRAY['nested_object']::text[]
+          FROM pg_tview_meta WHERE entity = 'post') THEN
+    RAISE EXCEPTION '#56 cascade setup FAIL: post not nested_object';
+  END IF;
+END $$;
+
+CREATE FUNCTION _rc() RETURNS bigint LANGUAGE sql AS
+  $$ SELECT (pg_tviews_queue_stats()->>'view_recomputes')::bigint $$;
+CREATE FUNCTION _applied() RETURNS bigint LANGUAGE sql AS
+  $$ SELECT (pg_tviews_queue_stats()->>'direct_patches_applied')::bigint $$;
+
+-- ── Cycle 2: one-level cascade (user → post.author), zero recomputes ──────────
+DO $$
+DECLARE rc0 bigint; ap0 bigint;
+BEGIN
+  rc0 := _rc(); ap0 := _applied();
+  UPDATE tb_user SET name = 'Bob' WHERE pk_user = 1;
+
+  IF _rc() <> rc0 THEN
+    RAISE EXCEPTION '#56 cascade FAIL: % view recompute(s) for a nested cascade', _rc() - rc0;
+  END IF;
+  -- user (1) + posts (3) + feeds (3) all patched directly.
+  IF _applied() - ap0 <> 7 THEN
+    RAISE EXCEPTION '#56 cascade FAIL: applied Δ% (expected 7)', _applied() - ap0;
+  END IF;
+
+  IF (SELECT count(*) FROM tv_post WHERE data->'author'->>'name' = 'Bob') <> 3 THEN
+    RAISE EXCEPTION '#56 cascade FAIL: not all posts got author.name=Bob';
+  END IF;
+  -- Sibling keys of author, top-level title, and the comments array are untouched.
+  IF (SELECT data->'author'->>'bio' FROM tv_post WHERE pk_post = 1) <> 'author-bio' THEN
+    RAISE EXCEPTION '#56 cascade FAIL: author.bio sibling clobbered';
+  END IF;
+  IF (SELECT data->>'title' FROM tv_post WHERE pk_post = 1) <> 'P1' THEN
+    RAISE EXCEPTION '#56 cascade FAIL: title clobbered';
+  END IF;
+  IF (SELECT jsonb_array_length(data->'comments') FROM tv_post WHERE pk_post = 1) <> 2 THEN
+    RAISE EXCEPTION '#56 cascade FAIL: comments array disturbed by author patch';
+  END IF;
+  -- Two-level: feed.post.author reflects the change.
+  IF (SELECT count(*) FROM tv_feed WHERE data->'post'->'author'->>'name' = 'Bob') <> 3 THEN
+    RAISE EXCEPTION '#56 cascade FAIL: feed.post.author.name not propagated (two-level)';
+  END IF;
+END $$;
+
+-- ── Byte-identity: fast-path result == forced full recompute ─────────────────
+DO $$
+DECLARE fast_post jsonb; fast_feed jsonb; rec_post jsonb; rec_feed jsonb;
+BEGIN
+  UPDATE tb_user SET name = 'Carol', bio = 'new-bio' WHERE pk_user = 1;  -- fast path
+  SELECT jsonb_agg(data ORDER BY pk_post) INTO fast_post FROM tv_post;
+  SELECT jsonb_agg(data ORDER BY pk_feed) INTO fast_feed FROM tv_feed;
+
+  PERFORM pg_tviews_refresh('user');
+  PERFORM pg_tviews_refresh('post');
+  PERFORM pg_tviews_refresh('feed');
+  SELECT jsonb_agg(data ORDER BY pk_post) INTO rec_post FROM tv_post;
+  SELECT jsonb_agg(data ORDER BY pk_feed) INTO rec_feed FROM tv_feed;
+
+  IF fast_post <> rec_post THEN
+    RAISE EXCEPTION '#56 cascade FAIL: tv_post fast-path not byte-identical to recompute';
+  END IF;
+  IF fast_feed <> rec_feed THEN
+    RAISE EXCEPTION '#56 cascade FAIL: tv_feed fast-path not byte-identical to recompute';
+  END IF;
+END $$;
+
+-- ── GUC-off differential: same mutation, GUC toggled, identical result ────────
+DO $$
+DECLARE on_data jsonb; off_data jsonb;
+BEGIN
+  SET pg_tviews.direct_patch_enabled = on;
+  UPDATE tb_user SET name = 'Dave' WHERE pk_user = 1;
+  SELECT jsonb_agg(data ORDER BY pk_post) INTO on_data FROM tv_post;
+
+  SET pg_tviews.direct_patch_enabled = off;
+  UPDATE tb_user SET name = 'Dave' WHERE pk_user = 1;   -- no-op value, forces recompute
+  SELECT jsonb_agg(data ORDER BY pk_post) INTO off_data FROM tv_post;
+  SET pg_tviews.direct_patch_enabled = on;
+
+  IF on_data <> off_data THEN
+    RAISE EXCEPTION '#56 cascade FAIL: GUC on/off differ for the cascade';
+  END IF;
+END $$;
+
+-- ── Cycle 4: child fallback → parent recompute (poison propagation) ──────────
+-- The CHILD (direct-entity) tview row is missing, so its own patch RETURNs
+-- nothing ⇒ the child recomputes. A recomputed child cannot yield a trustworthy
+-- derived patch, so its parents must recompute too (poison), not patch. Final
+-- state is correct everywhere.
+DO $$
+DECLARE rc0 bigint; fb0 bigint;
+BEGIN
+  DELETE FROM tv_user WHERE pk_user = 1;   -- child row missing
+  rc0 := _rc(); fb0 := (pg_tviews_queue_stats()->>'direct_patch_fallbacks')::bigint;
+  UPDATE tb_user SET name = 'Eve' WHERE pk_user = 1;
+
+  -- Child fell back at least once, and recompute(s) ran for the child + parents.
+  IF (pg_tviews_queue_stats()->>'direct_patch_fallbacks')::bigint - fb0 < 1 THEN
+    RAISE EXCEPTION '#56 cascade FAIL: missing child row did not fall back';
+  END IF;
+  IF _rc() = rc0 THEN
+    RAISE EXCEPTION '#56 cascade FAIL: child fallback did not trigger recompute';
+  END IF;
+  -- The child row was re-materialised and all its posts reflect the change.
+  IF (SELECT data->>'name' FROM tv_user WHERE pk_user = 1) <> 'Eve' THEN
+    RAISE EXCEPTION '#56 cascade FAIL: recomputed child row wrong/missing';
+  END IF;
+  IF (SELECT count(*) FROM tv_post WHERE data->'author'->>'name' = 'Eve') <> 3 THEN
+    RAISE EXCEPTION '#56 cascade FAIL: parents of a fallen-back child not refreshed';
+  END IF;
+  IF (SELECT data->>'title' FROM tv_post WHERE pk_post = 2) <> 'P2' THEN
+    RAISE EXCEPTION '#56 cascade FAIL: recomputed post lost its title';
+  END IF;
+END $$;
+
+SELECT 'issue #56 cascade: PASS' AS result;

--- a/test/sql/regress_issue_56_catalog.sql
+++ b/test/sql/regress_issue_56_catalog.sql
@@ -1,0 +1,100 @@
+-- Regression test for issue #56 (Phase 1): direct-patch column→key catalog map.
+--
+-- CREATE-time extraction records, per entity, which base-table columns map
+-- identity-style to top-level keys of the entity's own `data` object. Bare base
+-- columns are captured; nested objects / joined relations / expressions are not.
+--
+--   psql -v ON_ERROR_STOP=1 -f test/sql/regress_issue_56_catalog.sql
+
+\set ON_ERROR_STOP on
+SET client_min_messages TO WARNING;
+
+DROP EXTENSION IF EXISTS pg_tviews CASCADE;
+DROP EXTENSION IF EXISTS jsonb_delta CASCADE;
+CREATE EXTENSION jsonb_delta;
+CREATE EXTENSION pg_tviews;
+
+DROP TABLE IF EXISTS tv_post CASCADE;
+DROP VIEW  IF EXISTS v_post CASCADE;
+DROP TABLE IF EXISTS tv_user CASCADE;
+DROP VIEW  IF EXISTS v_user CASCADE;
+DROP TABLE IF EXISTS tb_post CASCADE;
+DROP TABLE IF EXISTS tb_user CASCADE;
+
+CREATE TABLE tb_user (
+    pk_user INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id      UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    name    TEXT,
+    bio     TEXT
+);
+CREATE TABLE tb_post (
+    pk_post INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id      UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    fk_user INTEGER REFERENCES tb_user(pk_user),
+    title   TEXT
+);
+INSERT INTO tb_user (name, bio) VALUES ('Alice', 'hello');
+INSERT INTO tb_post (fk_user, title) VALUES (1, 'Original');
+
+-- tv_user: two bare base columns map identity-style (name, bio).
+SELECT pg_tviews_create('tv_user', $TVIEW$
+    SELECT pk_user, id, jsonb_build_object('name', name, 'bio', bio) AS data
+    FROM tb_user
+$TVIEW$);
+
+-- tv_post: `title` is a bare (table-qualified) base column ⇒ mapped;
+-- `author` embeds v_user.data (a joined relation) ⇒ NOT mapped.
+SELECT pg_tviews_create('tv_post', $TVIEW$
+    SELECT tb_post.pk_post, tb_post.id, tb_post.fk_user,
+           jsonb_build_object('title', tb_post.title, 'author', v_user.data) AS data
+    FROM tb_post LEFT JOIN v_user ON v_user.pk_user = tb_post.fk_user
+$TVIEW$);
+
+-- (1) tv_user map: exactly {name→name, bio→bio}, order-independent.
+DO $$
+DECLARE cols text[]; keys text[];
+BEGIN
+  SELECT direct_map_columns, direct_map_keys INTO cols, keys
+  FROM pg_tview_meta WHERE entity = 'user';
+
+  IF NOT (cols @> ARRAY['name','bio']::text[] AND cols <@ ARRAY['name','bio']::text[]) THEN
+    RAISE EXCEPTION '#56 FAIL: user direct_map_columns is % (expected name,bio)', cols;
+  END IF;
+  IF NOT (keys @> ARRAY['name','bio']::text[] AND keys <@ ARRAY['name','bio']::text[]) THEN
+    RAISE EXCEPTION '#56 FAIL: user direct_map_keys is % (expected name,bio)', keys;
+  END IF;
+  -- Aligned by index: the key for column `bio` must be `bio`.
+  IF keys[array_position(cols, 'bio')] <> 'bio' THEN
+    RAISE EXCEPTION '#56 FAIL: user map misaligned (bio → %)', keys[array_position(cols, 'bio')];
+  END IF;
+END $$;
+
+-- (2) tv_post map: contains `title` (bare base col), NOT `author` / not the
+--     joined `v_user.data`.
+DO $$
+DECLARE cols text[]; keys text[];
+BEGIN
+  SELECT direct_map_columns, direct_map_keys INTO cols, keys
+  FROM pg_tview_meta WHERE entity = 'post';
+
+  IF NOT (cols @> ARRAY['title']::text[]) THEN
+    RAISE EXCEPTION '#56 FAIL: post direct_map_columns missing title (got %)', cols;
+  END IF;
+  IF cols @> ARRAY['author']::text[] OR keys @> ARRAY['author']::text[] THEN
+    RAISE EXCEPTION '#56 FAIL: post map wrongly captured the nested author key (cols=%, keys=%)', cols, keys;
+  END IF;
+  IF keys[array_position(cols, 'title')] <> 'title' THEN
+    RAISE EXCEPTION '#56 FAIL: post map misaligned for title (got %)',
+      keys[array_position(cols, 'title')];
+  END IF;
+END $$;
+
+-- (3) Column/key arrays are always aligned in length for every tview.
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tview_meta
+             WHERE cardinality(direct_map_columns) <> cardinality(direct_map_keys)) THEN
+    RAISE EXCEPTION '#56 FAIL: direct_map_columns / direct_map_keys length mismatch';
+  END IF;
+END $$;
+
+SELECT 'issue #56 catalog map: PASS' AS result;

--- a/test/sql/regress_issue_56_differential.sql
+++ b/test/sql/regress_issue_56_differential.sql
@@ -1,0 +1,191 @@
+-- Regression test for issue #56 (Phase 5): differential byte-identity + fallbacks.
+--
+-- Acceptance criterion: an eligible fast-path UPDATE yields tv_*.data byte-identical
+-- to a full recompute. Each eligible scenario runs the mutation, snapshots the data,
+-- forces a recompute (pg_tviews_refresh), and asserts equality — plus 0 view
+-- recomputes on the fast path. Each fallback scenario asserts a recompute ran and
+-- the result is correct.
+--
+--   psql -v ON_ERROR_STOP=1 -f test/sql/regress_issue_56_differential.sql
+
+\set ON_ERROR_STOP on
+SET client_min_messages TO WARNING;
+
+DROP EXTENSION IF EXISTS pg_tviews CASCADE;
+DROP EXTENSION IF EXISTS jsonb_delta CASCADE;
+CREATE EXTENSION jsonb_delta;
+CREATE EXTENSION pg_tviews;
+
+CREATE FUNCTION _rc() RETURNS bigint LANGUAGE sql AS
+  $$ SELECT (pg_tviews_queue_stats()->>'view_recomputes')::bigint $$;
+
+-- ══ Part A: eligible scenarios — byte-identity + zero recomputes ═════════════
+DROP TABLE IF EXISTS tv_thing CASCADE; DROP VIEW IF EXISTS v_thing CASCADE;
+DROP TABLE IF EXISTS tb_thing CASCADE;
+CREATE TABLE tb_thing (
+    pk_thing INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    s TEXT, n_int INTEGER, n_big BIGINT, n_small SMALLINT,
+    flag BOOLEAN, uu UUID, jj JSONB, headline TEXT
+);
+INSERT INTO tb_thing (s, n_int, n_big, n_small, flag, uu, jj, headline)
+VALUES ('s0', 1, 100, 5, true, '11111111-1111-1111-1111-111111111111', '{"k":"v"}', 'H0');
+
+-- Key names deliberately differ from column names for several fields.
+SELECT pg_tviews_create('tv_thing', $TVIEW$
+    SELECT pk_thing, id, jsonb_build_object(
+        's', s, 'i', n_int, 'big', n_big, 'small', n_small,
+        'flag', flag, 'uid', uu, 'meta', jj, 'headline_key', headline
+    ) AS data
+    FROM tb_thing
+$TVIEW$);
+
+-- Differential helper: run `mutation`, snapshot fast data, force recompute,
+-- assert byte-identity AND that the fast path did zero recomputes.
+CREATE FUNCTION _diff(mutation text, label text) RETURNS void LANGUAGE plpgsql AS $$
+DECLARE fast jsonb; rec jsonb; rc0 bigint;
+BEGIN
+  rc0 := _rc();
+  EXECUTE mutation;
+  IF _rc() <> rc0 THEN
+    RAISE EXCEPTION '#56 diff [%]: eligible mutation did % view recompute(s)', label, _rc() - rc0;
+  END IF;
+  SELECT data INTO fast FROM tv_thing WHERE pk_thing = 1;
+  PERFORM pg_tviews_refresh('thing');
+  SELECT data INTO rec FROM tv_thing WHERE pk_thing = 1;
+  IF fast IS DISTINCT FROM rec THEN
+    RAISE EXCEPTION '#56 diff [%]: fast % <> recompute %', label, fast, rec;
+  END IF;
+END $$;
+
+SELECT _diff($$UPDATE tb_thing SET s = 'text-changed' WHERE pk_thing = 1$$, 'text');
+SELECT _diff($$UPDATE tb_thing SET n_int = 42 WHERE pk_thing = 1$$, 'int4');
+SELECT _diff($$UPDATE tb_thing SET n_big = 9000000000 WHERE pk_thing = 1$$, 'int8');
+SELECT _diff($$UPDATE tb_thing SET n_small = 7 WHERE pk_thing = 1$$, 'int2');
+SELECT _diff($$UPDATE tb_thing SET flag = false WHERE pk_thing = 1$$, 'bool');
+SELECT _diff($$UPDATE tb_thing SET uu = '22222222-2222-2222-2222-222222222222' WHERE pk_thing = 1$$, 'uuid');
+SELECT _diff($$UPDATE tb_thing SET jj = '{"k2":[1,2,3]}'::jsonb WHERE pk_thing = 1$$, 'jsonb');
+SELECT _diff($$UPDATE tb_thing SET headline = 'H1' WHERE pk_thing = 1$$, 'key<>column');
+SELECT _diff($$UPDATE tb_thing SET s = 'multi', n_int = 99 WHERE pk_thing = 1$$, 'multi-column');
+-- NULL value: set-to-null, byte-identical to jsonb_build_object emitting json null.
+SELECT _diff($$UPDATE tb_thing SET s = NULL WHERE pk_thing = 1$$, 'null-value');
+DO $$ BEGIN
+  IF (SELECT data ? 's' AND data->>'s' IS NULL FROM tv_thing WHERE pk_thing=1) IS NOT TRUE THEN
+    RAISE EXCEPTION '#56 diff [null-value]: key not present-as-null';
+  END IF;
+END $$;
+-- No-op update (unchanged value): datumIsEqual finds no changed column, so nothing
+-- is captured and the key plain-enqueues (recompute) — current behaviour, kept.
+-- Only correctness is asserted (a no-op patch would be an optimisation, not a fix).
+DO $$
+DECLARE before jsonb;
+BEGIN
+  SELECT data INTO before FROM tv_thing WHERE pk_thing = 1;
+  UPDATE tb_thing SET n_int = n_int WHERE pk_thing = 1;
+  IF (SELECT data FROM tv_thing WHERE pk_thing = 1) IS DISTINCT FROM before THEN
+    RAISE EXCEPTION '#56 diff [no-op]: value-preserving update changed the data';
+  END IF;
+END $$;
+
+-- ══ Part B: fallback scenarios — recompute runs, result correct ══════════════
+
+-- (#15) Unsupported mapped type (timestamptz): capture declines ⇒ recompute.
+DROP TABLE IF EXISTS tv_ts CASCADE; DROP VIEW IF EXISTS v_ts CASCADE;
+DROP TABLE IF EXISTS tb_ts CASCADE;
+CREATE TABLE tb_ts (pk_ts INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                    id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE, at TIMESTAMPTZ);
+INSERT INTO tb_ts (at) VALUES ('2020-01-01T00:00:00Z');
+SELECT pg_tviews_create('tv_ts', $TVIEW$
+    SELECT pk_ts, id, jsonb_build_object('at', at) AS data FROM tb_ts
+$TVIEW$);
+DO $$
+DECLARE rc0 bigint;
+BEGIN
+  rc0 := _rc();
+  UPDATE tb_ts SET at = '2021-06-15T12:30:00Z' WHERE pk_ts = 1;
+  IF _rc() = rc0 THEN
+    RAISE EXCEPTION '#56 diff [timestamptz]: unsupported type did not fall back to recompute';
+  END IF;
+  IF (SELECT (data->>'at')::timestamptz FROM tv_ts WHERE pk_ts = 1) <> '2021-06-15T12:30:00Z'::timestamptz THEN
+    RAISE EXCEPTION '#56 diff [timestamptz]: recompute wrong';
+  END IF;
+END $$;
+
+-- (#11) Column also projected as a separate tv output column ⇒ recompute keeps both
+-- the tv column and the data key in sync.
+DROP TABLE IF EXISTS tv_proj CASCADE; DROP VIEW IF EXISTS v_proj CASCADE;
+DROP TABLE IF EXISTS tb_proj CASCADE;
+CREATE TABLE tb_proj (pk_proj INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                      id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE, title TEXT);
+INSERT INTO tb_proj (title) VALUES ('orig');
+SELECT pg_tviews_create('tv_proj', $TVIEW$
+    SELECT pk_proj, id, title, jsonb_build_object('title', title) AS data FROM tb_proj
+$TVIEW$);
+DO $$
+DECLARE rc0 bigint;
+BEGIN
+  rc0 := _rc();
+  UPDATE tb_proj SET title = 'changed' WHERE pk_proj = 1;
+  IF _rc() = rc0 THEN
+    RAISE EXCEPTION '#56 diff [projected-col]: expected recompute (title is a tv column)';
+  END IF;
+  IF (SELECT title FROM tv_proj WHERE pk_proj = 1) <> 'changed'
+     OR (SELECT data->>'title' FROM tv_proj WHERE pk_proj = 1) <> 'changed' THEN
+    RAISE EXCEPTION '#56 diff [projected-col]: tv column and data key out of sync';
+  END IF;
+END $$;
+
+-- (#12) Filter-column change: row leaves the tview, then returns (DELETE-on-missing).
+DROP TABLE IF EXISTS tv_flt CASCADE; DROP VIEW IF EXISTS v_flt CASCADE;
+DROP TABLE IF EXISTS tb_flt CASCADE;
+CREATE TABLE tb_flt (pk_flt INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                     id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE, status TEXT, body TEXT);
+INSERT INTO tb_flt (status, body) VALUES ('active', 'b1');
+SELECT pg_tviews_create('tv_flt', $TVIEW$
+    SELECT pk_flt, id, jsonb_build_object('body', body) AS data
+    FROM tb_flt WHERE status = 'active'
+$TVIEW$);
+DO $$ BEGIN
+  IF (SELECT count(*) FROM tv_flt WHERE pk_flt = 1) <> 1 THEN
+    RAISE EXCEPTION '#56 diff [filter]: setup — row should be present';
+  END IF;
+  -- Leave the filter: row must disappear from the tview.
+  UPDATE tb_flt SET status = 'archived' WHERE pk_flt = 1;
+  IF (SELECT count(*) FROM tv_flt WHERE pk_flt = 1) <> 0 THEN
+    RAISE EXCEPTION '#56 diff [filter]: row did not leave the tview on filter change';
+  END IF;
+  -- Return to the filter: row must reappear.
+  UPDATE tb_flt SET status = 'active' WHERE pk_flt = 1;
+  IF (SELECT data->>'body' FROM tv_flt WHERE pk_flt = 1) <> 'b1' THEN
+    RAISE EXCEPTION '#56 diff [filter]: row did not return on filter change';
+  END IF;
+END $$;
+
+-- (#17) DISTINCT ON tview: different refresh machinery ⇒ never fast-pathed.
+DROP TABLE IF EXISTS tv_dedup CASCADE; DROP VIEW IF EXISTS v_dedup CASCADE;
+DROP TABLE IF EXISTS tb_dedup CASCADE;
+CREATE TABLE tb_dedup (pk_dedup INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                       id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+                       grp INTEGER, ord INTEGER, label TEXT);
+INSERT INTO tb_dedup (grp, ord, label) VALUES (1, 1, 'a'), (1, 2, 'b');
+SELECT pg_tviews_create('tv_dedup', $TVIEW$
+    SELECT DISTINCT ON (grp) grp AS pk_dedup, id,
+           jsonb_build_object('label', label) AS data
+    FROM tb_dedup ORDER BY grp, ord DESC
+$TVIEW$);
+-- DISTINCT ON refresh uses refresh_by_dedup_key (not the recompute_view_row path),
+-- so the signal is that it is never fast-patched: direct_patches_applied is flat.
+DO $$
+DECLARE ap0 bigint;
+BEGIN
+  ap0 := (pg_tviews_queue_stats()->>'direct_patches_applied')::bigint;
+  UPDATE tb_dedup SET label = 'b2' WHERE pk_dedup = 2;
+  IF (pg_tviews_queue_stats()->>'direct_patches_applied')::bigint <> ap0 THEN
+    RAISE EXCEPTION '#56 diff [distinct-on]: a DISTINCT ON tview was fast-patched';
+  END IF;
+  IF (SELECT data->>'label' FROM tv_dedup WHERE pk_dedup = 1) <> 'b2' THEN
+    RAISE EXCEPTION '#56 diff [distinct-on]: dedup refresh wrong';
+  END IF;
+END $$;
+
+SELECT 'issue #56 differential: PASS' AS result;

--- a/test/sql/regress_issue_56_direct_entity.sql
+++ b/test/sql/regress_issue_56_direct_entity.sql
@@ -1,0 +1,175 @@
+-- Regression test for issue #56 (Phase 3): flush-time direct patch, direct entity.
+--
+-- An eligible UPDATE patches tv_<entity> directly via jsonb_smart_patch_scalar with
+-- ZERO backing-view queries; untouched JSONB keys stay byte-identical; missing rows,
+-- GUC-off, and ineligible (poisoning) changes all fall back to recompute.
+--
+-- Standalone tv_user (no parent) so "view_recomputes unchanged" isolates the
+-- direct-entity path.
+--
+--   psql -v ON_ERROR_STOP=1 -f test/sql/regress_issue_56_direct_entity.sql
+
+\set ON_ERROR_STOP on
+SET client_min_messages TO WARNING;
+
+DROP EXTENSION IF EXISTS pg_tviews CASCADE;
+DROP EXTENSION IF EXISTS jsonb_delta CASCADE;
+CREATE EXTENSION jsonb_delta;
+CREATE EXTENSION pg_tviews;
+
+DROP TABLE IF EXISTS tv_user CASCADE;
+DROP VIEW  IF EXISTS v_user CASCADE;
+DROP TABLE IF EXISTS tb_user CASCADE;
+
+CREATE TABLE tb_user (
+    pk_user INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id      UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    name    TEXT,
+    bio     TEXT,
+    status  TEXT
+);
+INSERT INTO tb_user (name, bio, status)
+     VALUES ('Alice', 'a0', 'active'), ('Bob', 'b0', 'active'), ('Carol', 'c0', 'active');
+
+SELECT pg_tviews_create('tv_user', $TVIEW$
+    SELECT pk_user, id, jsonb_build_object('name', name, 'bio', bio) AS data
+    FROM tb_user
+$TVIEW$);
+
+-- Counter-delta helper over (applied, fallbacks, view_recomputes).
+CREATE TEMP TABLE _c(applied bigint, fallbacks bigint, recomputes bigint);
+INSERT INTO _c
+SELECT (s->>'direct_patches_applied')::bigint,
+       (s->>'direct_patch_fallbacks')::bigint,
+       (s->>'view_recomputes')::bigint
+FROM (SELECT pg_tviews_queue_stats() AS s) x;
+
+CREATE FUNCTION _c_assert(exp_applied bigint, exp_fb bigint, exp_rc bigint, label text)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE s jsonb; a bigint; f bigint; r bigint; pa bigint; pf bigint; pr bigint;
+BEGIN
+  s := pg_tviews_queue_stats();
+  a := (s->>'direct_patches_applied')::bigint;
+  f := (s->>'direct_patch_fallbacks')::bigint;
+  r := (s->>'view_recomputes')::bigint;
+  SELECT applied, fallbacks, recomputes INTO pa, pf, pr FROM _c;
+  IF a - pa <> exp_applied OR f - pf <> exp_fb OR r - pr <> exp_rc THEN
+    RAISE EXCEPTION '#56 [%] counters: applied Δ%/exp%, fallback Δ%/exp%, recompute Δ%/exp%',
+      label, a - pa, exp_applied, f - pf, exp_fb, r - pr, exp_rc;
+  END IF;
+  UPDATE _c SET applied = a, fallbacks = f, recomputes = r;
+END $$;
+
+-- ── Cycle 1: single eligible column, direct patch, merge semantics ───────────
+-- Baseline for updated_at bump.
+CREATE TEMP TABLE _ts AS SELECT updated_at AS u FROM tv_user WHERE pk_user = 1;
+SELECT pg_sleep(0.02);
+
+UPDATE tb_user SET bio = 'a1' WHERE pk_user = 1;
+SELECT _c_assert(1, 0, 0, 'single eligible bio: patched, no recompute');
+
+DO $$ BEGIN
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1) <> 'a1' THEN
+    RAISE EXCEPTION '#56 FAIL: bio not patched (got %)',
+      (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1);
+  END IF;
+  -- Merge, not replace: the untouched `name` key survives.
+  IF (SELECT data->>'name' FROM tv_user WHERE pk_user = 1) <> 'Alice' THEN
+    RAISE EXCEPTION '#56 FAIL: merge clobbered name (got %)',
+      (SELECT data->>'name' FROM tv_user WHERE pk_user = 1);
+  END IF;
+  -- Exactly the two expected keys remain.
+  IF (SELECT count(*) FROM jsonb_object_keys((SELECT data FROM tv_user WHERE pk_user=1))) <> 2 THEN
+    RAISE EXCEPTION '#56 FAIL: unexpected key set %',
+      (SELECT data FROM tv_user WHERE pk_user = 1);
+  END IF;
+  -- updated_at bumped.
+  IF (SELECT updated_at FROM tv_user WHERE pk_user = 1) <= (SELECT u FROM _ts) THEN
+    RAISE EXCEPTION '#56 FAIL: updated_at not bumped by direct patch';
+  END IF;
+END $$;
+
+-- Multi-column eligible in one row ⇒ one applied row, no recompute.
+UPDATE tb_user SET bio = 'a2', name = 'Alice2' WHERE pk_user = 1;
+SELECT _c_assert(1, 0, 0, 'multi-column eligible: one applied');
+DO $$ BEGIN
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user=1) <> 'a2'
+     OR (SELECT data->>'name' FROM tv_user WHERE pk_user=1) <> 'Alice2' THEN
+    RAISE EXCEPTION '#56 FAIL: multi-column patch wrong (%)',
+      (SELECT data FROM tv_user WHERE pk_user = 1);
+  END IF;
+END $$;
+
+-- ── Cycle 2: bulk grouping + batch chunking ──────────────────────────────────
+-- Same new value for many rows ⇒ one chain group; 3 rows applied, 0 recomputes.
+UPDATE tb_user SET bio = 'shared' WHERE pk_user IN (1, 2, 3);
+SELECT _c_assert(3, 0, 0, 'bulk same-value: 3 applied');
+DO $$ BEGIN
+  IF (SELECT count(*) FROM tv_user WHERE data->>'bio' = 'shared') <> 3 THEN
+    RAISE EXCEPTION '#56 FAIL: bulk same-value patch missed rows';
+  END IF;
+END $$;
+
+-- Distinct new value per row (different chains) under a small batch_size.
+SET pg_tviews.batch_size = 2;
+UPDATE tb_user SET bio = 'v_' || pk_user::text WHERE pk_user IN (1, 2, 3);
+SELECT _c_assert(3, 0, 0, 'bulk distinct-value: 3 applied under batch_size=2');
+RESET pg_tviews.batch_size;
+DO $$ BEGIN
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user=1) <> 'v_1'
+     OR (SELECT data->>'bio' FROM tv_user WHERE pk_user=2) <> 'v_2'
+     OR (SELECT data->>'bio' FROM tv_user WHERE pk_user=3) <> 'v_3' THEN
+    RAISE EXCEPTION '#56 FAIL: distinct-value bulk patch wrong';
+  END IF;
+END $$;
+
+-- ── Cycle 3: fallbacks ───────────────────────────────────────────────────────
+-- (a) Missing tview row ⇒ patch RETURNING empty ⇒ recompute (UPSERT re-creates it).
+DELETE FROM tv_user WHERE pk_user = 2;
+UPDATE tb_user SET bio = 'reborn' WHERE pk_user = 2;
+SELECT _c_assert(0, 1, 1, 'missing row: fallback to recompute');
+DO $$ BEGIN
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user = 2) <> 'reborn'
+     OR (SELECT data->>'name' FROM tv_user WHERE pk_user = 2) <> 'Bob' THEN
+    RAISE EXCEPTION '#56 FAIL: fallback recompute produced wrong row (%)',
+      (SELECT data FROM tv_user WHERE pk_user = 2);
+  END IF;
+END $$;
+
+-- (b) GUC off between capture and commit ⇒ recompute, not patch.
+SET pg_tviews.direct_patch_enabled = off;
+UPDATE tb_user SET bio = 'guc_off' WHERE pk_user = 1;
+SELECT _c_assert(0, 0, 1, 'guc off: recompute');
+SET pg_tviews.direct_patch_enabled = on;
+DO $$ BEGIN
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1) <> 'guc_off' THEN
+    RAISE EXCEPTION '#56 FAIL: guc-off recompute wrong';
+  END IF;
+END $$;
+
+-- (c) Ineligible mixed change (bio mapped + status unmapped) poisons ⇒ recompute.
+UPDATE tb_user SET bio = 'mix', status = 'inactive' WHERE pk_user = 1;
+SELECT _c_assert(0, 0, 1, 'mixed eligible+unmapped: poison to recompute');
+DO $$ BEGIN
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1) <> 'mix' THEN
+    RAISE EXCEPTION '#56 FAIL: mixed-update recompute wrong';
+  END IF;
+END $$;
+
+-- ── Cycle 4: zero-view-query proof for the eligible direct-entity path ────────
+DO $$
+DECLARE before_rc bigint; after_rc bigint;
+BEGIN
+  before_rc := (pg_tviews_queue_stats()->>'view_recomputes')::bigint;
+  UPDATE tb_user SET bio = 'final' WHERE pk_user = 3;
+  after_rc := (pg_tviews_queue_stats()->>'view_recomputes')::bigint;
+  IF after_rc <> before_rc THEN
+    RAISE EXCEPTION '#56 FAIL: eligible direct-entity UPDATE triggered % view recompute(s)',
+      after_rc - before_rc;
+  END IF;
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user = 3) <> 'final' THEN
+    RAISE EXCEPTION '#56 FAIL: zero-recompute update produced wrong data';
+  END IF;
+END $$;
+
+SELECT 'issue #56 direct entity: PASS' AS result;

--- a/test/sql/regress_issue_56_fallback_no_delta.sql
+++ b/test/sql/regress_issue_56_fallback_no_delta.sql
@@ -1,0 +1,58 @@
+-- Regression test for issue #56 (Phase 5, scenario #19): jsonb_delta NOT installed.
+--
+-- The direct-patch fast path requires the jsonb_smart_patch_* primitives, so with
+-- jsonb_delta absent capture must decline (no patch captured, none applied) and the
+-- full-replacement recompute path produces correct data.
+--
+-- Deliberately does NOT create the jsonb_delta extension (the runner still executes
+-- *fallback* tests when jsonb_delta is unavailable in the cluster).
+--
+--   psql -v ON_ERROR_STOP=1 -f test/sql/regress_issue_56_fallback_no_delta.sql
+
+\set ON_ERROR_STOP on
+SET client_min_messages TO WARNING;
+
+DROP EXTENSION IF EXISTS pg_tviews CASCADE;
+DROP EXTENSION IF EXISTS jsonb_delta CASCADE;
+CREATE EXTENSION pg_tviews;   -- no jsonb_delta on purpose
+
+DROP TABLE IF EXISTS tv_user CASCADE;
+DROP VIEW  IF EXISTS v_user CASCADE;
+DROP TABLE IF EXISTS tb_user CASCADE;
+
+CREATE TABLE tb_user (
+    pk_user INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id      UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    name    TEXT, bio TEXT
+);
+INSERT INTO tb_user (name, bio) VALUES ('Alice', 'b0');
+
+SELECT pg_tviews_create('tv_user', $TVIEW$
+    SELECT pk_user, id, jsonb_build_object('name', name, 'bio', bio) AS data
+    FROM tb_user
+$TVIEW$);
+
+-- An otherwise-eligible single-column UPDATE: capture must decline (no jsonb_delta),
+-- neither captured nor applied, and the full-replacement path must produce the row.
+DO $$
+DECLARE cap0 bigint; app0 bigint;
+BEGIN
+  cap0 := (pg_tviews_queue_stats()->>'direct_patch_captured')::bigint;
+  app0 := (pg_tviews_queue_stats()->>'direct_patches_applied')::bigint;
+
+  UPDATE tb_user SET bio = 'b1' WHERE pk_user = 1;
+
+  IF (pg_tviews_queue_stats()->>'direct_patch_captured')::bigint <> cap0 THEN
+    RAISE EXCEPTION '#56 no-delta FAIL: a patch was captured without jsonb_delta';
+  END IF;
+  IF (pg_tviews_queue_stats()->>'direct_patches_applied')::bigint <> app0 THEN
+    RAISE EXCEPTION '#56 no-delta FAIL: a patch was applied without jsonb_delta';
+  END IF;
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1) <> 'b1'
+     OR (SELECT data->>'name' FROM tv_user WHERE pk_user = 1) <> 'Alice' THEN
+    RAISE EXCEPTION '#56 no-delta FAIL: full-replacement recompute wrong (%)',
+      (SELECT data FROM tv_user WHERE pk_user = 1);
+  END IF;
+END $$;
+
+SELECT 'issue #56 fallback (no jsonb_delta): PASS' AS result;

--- a/test/sql/regress_issue_56_jsonb_delta_probe.sql
+++ b/test/sql/regress_issue_56_jsonb_delta_probe.sql
@@ -1,0 +1,49 @@
+-- Contract probe for issue #56 (Phase 4 Cycle 0): jsonb_smart_patch_nested must
+-- MERGE the source at the target path, preserving sibling keys — NOT replace the
+-- object at the path. Parent patch derivation applies the child's changed fields
+-- at the embedding path; replace-at-path would clobber the embedded object's other
+-- keys (e.g. author.name lost when patching author.bio). If this probe fails,
+-- STOP and re-plan — the whole cascade fast path depends on merge semantics.
+--
+-- NULL values are set-to-null (not stripped), matching jsonb_build_object output,
+-- so NULL new-values stay eligible.
+--
+--   psql -v ON_ERROR_STOP=1 -f test/sql/regress_issue_56_jsonb_delta_probe.sql
+
+\set ON_ERROR_STOP on
+SET client_min_messages TO WARNING;
+
+DROP EXTENSION IF EXISTS jsonb_delta CASCADE;
+CREATE EXTENSION jsonb_delta;
+
+DO $$ BEGIN
+  -- 1-segment nested merge keeps sibling `name`, updates `bio`, keeps top-level `title`.
+  IF jsonb_smart_patch_nested(
+        '{"author":{"name":"A","bio":"old"},"title":"T"}'::jsonb,
+        '{"bio":"new"}'::jsonb, ARRAY['author'])
+     <> '{"author":{"name":"A","bio":"new"},"title":"T"}'::jsonb THEN
+    RAISE EXCEPTION '#56 PROBE FAIL: nested patch is not merge-at-path (1 segment)';
+  END IF;
+
+  -- 2-segment nested path merges at the deep path.
+  IF jsonb_smart_patch_nested(
+        '{"post":{"author":{"name":"A","bio":"old"}}}'::jsonb,
+        '{"bio":"new"}'::jsonb, ARRAY['post','author'])
+     <> '{"post":{"author":{"name":"A","bio":"new"}}}'::jsonb THEN
+    RAISE EXCEPTION '#56 PROBE FAIL: nested patch is not merge-at-path (2 segments)';
+  END IF;
+
+  -- Top-level scalar merge keeps siblings.
+  IF jsonb_smart_patch_scalar('{"name":"A","bio":"old"}'::jsonb, '{"bio":"new"}'::jsonb)
+     <> '{"name":"A","bio":"new"}'::jsonb THEN
+    RAISE EXCEPTION '#56 PROBE FAIL: scalar patch is not a shallow merge';
+  END IF;
+
+  -- NULL is set-to-null, not deleted (byte-identical to jsonb_build_object('bio', NULL)).
+  IF jsonb_smart_patch_scalar('{"name":"A","bio":"old"}'::jsonb, '{"bio":null}'::jsonb)
+     <> '{"name":"A","bio":null}'::jsonb THEN
+    RAISE EXCEPTION '#56 PROBE FAIL: NULL value not preserved as json null';
+  END IF;
+END $$;
+
+SELECT 'issue #56 jsonb_delta probe: PASS' AS result;

--- a/test/sql/regress_issue_56_savepoint.sql
+++ b/test/sql/regress_issue_56_savepoint.sql
@@ -1,0 +1,77 @@
+-- Regression test for issue #56 (Phase 2/3): savepoint safety of the patch map.
+--
+-- The direct-patch map snapshots/restores in lockstep with the refresh queue on
+-- SAVEPOINT / ROLLBACK TO. A change captured inside a rolled-back savepoint must
+-- not survive; the final tview reflects only the pre-savepoint change. This holds
+-- whether the flush recomputes (Phase 2) or applies a direct patch (Phase 3),
+-- because the tview write is itself transactional.
+--
+--   psql -v ON_ERROR_STOP=1 -f test/sql/regress_issue_56_savepoint.sql
+
+\set ON_ERROR_STOP on
+SET client_min_messages TO WARNING;
+
+DROP EXTENSION IF EXISTS pg_tviews CASCADE;
+DROP EXTENSION IF EXISTS jsonb_delta CASCADE;
+CREATE EXTENSION jsonb_delta;
+CREATE EXTENSION pg_tviews;
+
+DROP TABLE IF EXISTS tv_user CASCADE;
+DROP VIEW  IF EXISTS v_user CASCADE;
+DROP TABLE IF EXISTS tb_user CASCADE;
+
+CREATE TABLE tb_user (
+    pk_user INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id      UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    bio     TEXT
+);
+INSERT INTO tb_user (bio) VALUES ('initial');
+
+SELECT pg_tviews_create('tv_user', $TVIEW$
+    SELECT pk_user, id, jsonb_build_object('bio', bio) AS data
+    FROM tb_user
+$TVIEW$);
+
+-- (1) ROLLBACK TO discards the savepoint-local change.
+BEGIN;
+  UPDATE tb_user SET bio = 'before-sp' WHERE pk_user = 1;
+  SAVEPOINT sp1;
+  UPDATE tb_user SET bio = 'inside-sp' WHERE pk_user = 1;
+  ROLLBACK TO sp1;
+COMMIT;
+
+DO $$ BEGIN
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1) <> 'before-sp' THEN
+    RAISE EXCEPTION '#56 savepoint FAIL: expected before-sp, got %',
+      (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1);
+  END IF;
+END $$;
+
+-- (2) RELEASE SAVEPOINT keeps the savepoint-local change.
+BEGIN;
+  UPDATE tb_user SET bio = 'pre-release' WHERE pk_user = 1;
+  SAVEPOINT sp2;
+  UPDATE tb_user SET bio = 'kept' WHERE pk_user = 1;
+  RELEASE SAVEPOINT sp2;
+COMMIT;
+
+DO $$ BEGIN
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1) <> 'kept' THEN
+    RAISE EXCEPTION '#56 savepoint FAIL: expected kept, got %',
+      (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1);
+  END IF;
+END $$;
+
+-- (3) Full transaction ABORT clears the patch map and leaves the tview unchanged.
+BEGIN;
+  UPDATE tb_user SET bio = 'aborted' WHERE pk_user = 1;
+ROLLBACK;
+
+DO $$ BEGIN
+  IF (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1) <> 'kept' THEN
+    RAISE EXCEPTION '#56 abort FAIL: expected kept (unchanged), got %',
+      (SELECT data->>'bio' FROM tv_user WHERE pk_user = 1);
+  END IF;
+END $$;
+
+SELECT 'issue #56 savepoint: PASS' AS result;

--- a/test/sql/regress_issue_56_security.sql
+++ b/test/sql/regress_issue_56_security.sql
@@ -1,0 +1,66 @@
+-- Regression test for issue #56 (Phase 7 security): exotic JSONB keys are omitted
+-- from the direct-patch column map, so nothing user-controlled is ever
+-- interpolated into generated SQL. Patch values are always bound as JSONB
+-- parameters; only path segments (from the analyzer's \w+ capture) reach an
+-- ARRAY['…'] literal, and even those are single-quote escaped.
+--
+--   psql -v ON_ERROR_STOP=1 -f test/sql/regress_issue_56_security.sql
+
+\set ON_ERROR_STOP on
+SET client_min_messages TO WARNING;
+
+DROP EXTENSION IF EXISTS pg_tviews CASCADE;
+DROP EXTENSION IF EXISTS jsonb_delta CASCADE;
+CREATE EXTENSION jsonb_delta;
+CREATE EXTENSION pg_tviews;
+
+DROP TABLE IF EXISTS tv_thing CASCADE; DROP VIEW IF EXISTS v_thing CASCADE;
+DROP TABLE IF EXISTS tb_thing CASCADE;
+CREATE TABLE tb_thing (pk_thing INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                       id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+                       safe TEXT, danger TEXT);
+INSERT INTO tb_thing (safe, danger) VALUES ('s0', 'd0');
+
+-- A key containing a quote + SQL-ish payload must NOT enter the column map.
+SELECT pg_tviews_create('tv_thing', $TVIEW$
+    SELECT pk_thing, id, jsonb_build_object(
+        'safe', safe,
+        'weird'')-- ; DROP TABLE tb_thing; --', danger
+    ) AS data
+    FROM tb_thing
+$TVIEW$);
+
+-- The safe key is mapped; the exotic key is omitted (so `danger` is never fast-pathed).
+DO $$
+DECLARE cols text[]; keys text[];
+BEGIN
+  SELECT direct_map_columns, direct_map_keys INTO cols, keys
+  FROM pg_tview_meta WHERE entity = 'thing';
+  IF NOT (cols @> ARRAY['safe']::text[]) THEN
+    RAISE EXCEPTION '#56 security FAIL: safe key not mapped (cols=%)', cols;
+  END IF;
+  IF cols @> ARRAY['danger']::text[] THEN
+    RAISE EXCEPTION '#56 security FAIL: exotic-key column entered the map (cols=%)', cols;
+  END IF;
+  IF EXISTS (SELECT 1 FROM unnest(keys) k WHERE k LIKE '%DROP%' OR k LIKE '%''%') THEN
+    RAISE EXCEPTION '#56 security FAIL: exotic key survived in the map (keys=%)', keys;
+  END IF;
+END $$;
+
+-- The tview still materialises and updates correctly (the exotic key via recompute,
+-- the safe key via the fast path). tb_thing must still exist (no injection executed).
+UPDATE tb_thing SET safe = 's1' WHERE pk_thing = 1;      -- eligible fast path
+UPDATE tb_thing SET danger = 'd1' WHERE pk_thing = 1;    -- unmapped ⇒ recompute
+DO $$ BEGIN
+  IF (SELECT to_regclass('tb_thing')) IS NULL THEN
+    RAISE EXCEPTION '#56 security FAIL: base table was dropped — injection executed!';
+  END IF;
+  IF (SELECT data->>'safe' FROM tv_thing WHERE pk_thing = 1) <> 's1' THEN
+    RAISE EXCEPTION '#56 security FAIL: safe fast-path value wrong';
+  END IF;
+  IF (SELECT data->>'weird'')-- ; DROP TABLE tb_thing; --' FROM tv_thing WHERE pk_thing = 1) <> 'd1' THEN
+    RAISE EXCEPTION '#56 security FAIL: exotic-key value not refreshed by recompute';
+  END IF;
+END $$;
+
+SELECT 'issue #56 security: PASS' AS result;


### PR DESCRIPTION
## Problem

On a base-table change, pg_tviews recomputes every affected projection row from the
backing view (`SELECT * FROM v_entity WHERE pk = ANY($1)`, JOINs + `jsonb_build_object`)
and writes it back. `jsonb_delta` makes only the **write** surgical — the **recompute**
runs for every changed row and every cascade fan-out row.

## Solution

For an `UPDATE` whose changed columns all map identity-style to top-level `data` keys
(`jsonb_build_object('bio', bio)`), build the patch **at trigger time from `NEW`**, carry
it through the transaction queue, and at flush time apply `jsonb_smart_patch_scalar/_nested`
directly to `tv_<entity>` — **zero backing-view queries**. The same patch is *derived* for
parent tviews that embed the entity as a nested object (path prepended), so a single-field
change with a wide fan-out propagates as a handful of grouped patch UPDATEs.

Anything outside the eligibility boundary falls back to today's recompute path, which stays
the single source of truth. The fast path is a pure optimization — its `data` output is
**byte-identical** to a recompute (an acceptance criterion, proven in the differential suite).

### Eligibility (every condition must hold, else recompute)

Row-level `UPDATE`; `jsonb_delta` present and `pg_tviews.direct_patch_enabled = on`; entity
not `DISTINCT ON`/`UNION`; every changed column maps identity-style to a `data` key; no
changed column is an FK, the PK, or a column projected outside `data`; changed value types in
{TEXT/VARCHAR, INT2/4/8, BOOL, UUID, JSONB, NULL}; (parents) dependency is `nested_object`
with a path. Poison stickiness makes a parent reached by both a patched and a recomputed
child recompute.

Sidesteps #52 by construction (patches only the changed keys at the exact path) — the #52
nested-own-column regression now runs *through* the fast path and stays correct. Interlocks
with #50 (array-dep parents recompute).

## Design summary

- **Catalog:** `pg_tview_meta.direct_map_columns` / `direct_map_keys`, extracted at
  `pg_tviews_create` from bare `jsonb_build_object` pairs (`src/schema/direct_map.rs`).
- **Capture:** row trigger diffs OLD/NEW via `datumIsEqual` over the tuple descriptor
  (type-agnostic, detects unmapped-column changes), captures `NEW` values with a
  `to_jsonb`-matching type whitelist, records into a transaction-local patch map
  (`src/queue/patch.rs`) beside `TX_REFRESH_QUEUE`. Poison-sticky; savepoint/abort safe.
- **Apply:** flush partitions each entity group into patched vs recompute; grouped
  `UPDATE … jsonb_smart_patch_*(data, $json) WHERE pk = ANY($pks) RETURNING pk` (values
  bound as JSONB params); RETURNING-diff fallback for missing rows (`src/refresh/direct.rs`).
- **Cascade:** `derive_parent_chain` prepends the nested-object dependency path to the
  child's chain; multi-level composes.
- **GUC:** `pg_tviews.direct_patch_enabled` (bool, default on). **Counters** in
  `pg_tviews_queue_stats()`: `direct_patch_captured`, `direct_patches_applied`,
  `direct_patch_fallbacks`, `view_recomputes`.

## Benchmark (`test/sql/real_benchmark/scalar_cascade_fanout.sh`)

1 author → N posts embedding `author`; `UPDATE tb_user SET bio = …`. Local, PG 18.1, debug.

| fan-out | config | writes/s | view recomputes | patches applied |
|---:|---|---:|---:|---:|
| 60  | GUC off | 35 | 122,000 | 0 |
| 60  | GUC on  | 48 | **0** | 122,000 |
| 300 | GUC off | 16 | 240,800 | 0 |
| 300 | GUC on  | 21 | **0** | 240,800 |

The decisive, portable result is **zero backing-view queries** (counter-proven). The
wall-clock ratio is modest (~1.3–1.4×) because today's baseline already bulk-recomputes
(#48's `refresh_bulk`); the issue's ~76× was vs a per-row recompute baseline that #48
replaced. No perf bug — one grouped UPDATE per entity, metadata cached, no per-key SPI. The
wall-clock win grows with document/JOIN complexity. Full analysis:
`test/sql/real_benchmark/results/issue_56_scalar_cascade_fanout.md`.

## Test evidence (CI does not run the SQL suites — run locally)

```
test/run_regression_tests.sh → regression: 19 passed, 0 failed, 0 skipped
test/run_integration_tests.sh → integration: 35 passed, 0 failed (of 35 files)
cargo clippy --no-default-features --features pg18 --all-targets -- -D warnings → clean
```

New #56 regression files: `catalog`, `capture`, `savepoint`, `direct_entity`,
`jsonb_delta_probe`, `cascade`, `differential`, `fallback_no_delta`, `security`.
Coverage: byte-identity across all whitelisted types + key≠column + NULL + cascade
(1- & 2-level, vs forced recompute and vs GUC-off); fallbacks for FK/mixed/insert/delete/
missing-row/GUC-off/poison/unsupported-type/projected-column/filter-column/DISTINCT-ON/
no-jsonb_delta; savepoint rollback/release/abort; security (exotic keys omitted).

**Upgrade note:** the column→key map is extracted at create time, so tviews created before
this version stay on the recompute path until re-created.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)
