### PR TITLE
feat(cascade): multi-hop column-aware propagation prune

### DIFF
--- a/src/queue/graph.rs
+++ b/src/queue/graph.rs
@@ -1,4 +1,5 @@
 use crate::TViewResult;
+use crate::cascade_path::CascadePath;
 use pgrx::prelude::*;
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -13,9 +14,22 @@ use std::collections::{HashMap, HashSet, VecDeque};
 /// Topological order: `["company", "user", "post", "feed"]`
 #[derive(Debug, Clone)]
 pub struct EntityDepGraph {
-    /// Parent relationships: entity -> list of entities that depend on it
-    /// Example: "user" -> `["post", "feed"]`
-    #[allow(dead_code)] // Reason: public API for graph introspection; populated during load()
+    /// Propagation parents: entity -> list of entities that must be *entity-level*
+    /// refreshed (via [`crate::propagate`]) when it changes during flush.
+    ///
+    /// An edge is kept when the parent embeds part of this entity's *computed*
+    /// document that a base-table cascade path cannot cover on its own — i.e. a
+    /// `nested_object`/`array` embed, or a scalar embed that follows one of this
+    /// entity's foreign keys to reach a deeper relationship.
+    ///
+    /// **A scalar embed that reads only the child's own (non-FK) columns is excluded.**
+    /// Such an embed (e.g. `jsonb_build_object('title', p.title)`) can change only when
+    /// a child base-table column changes, which already fires the child's trigger and
+    /// cascades through the column-aware `tb_<child>` path — entity-level propagation is
+    /// then pure redundancy, and worse, it fires even when the child was recomputed for
+    /// an *unrelated* deeper embed (a post recomputed for an author-bio change would
+    /// otherwise recompute every comment that embeds only the post's `{id, title}`).
+    /// See [`EntityDepGraph::load`].
     pub parents: HashMap<String, Vec<String>>,
 
     /// Child relationships: entity -> list of entities it depends on
@@ -31,8 +45,13 @@ pub struct EntityDepGraph {
 impl EntityDepGraph {
     /// Build dependency graph from `pg_tview_meta`
     pub fn load() -> TViewResult<Self> {
-        // Query pg_tview_meta for all entities and their FK columns
-        let query = "SELECT entity, fk_columns FROM pg_tview_meta";
+        // `fk_columns[i]` names the relationship this entity embeds; `dependency_types[i]`
+        // classifies that embed (scalar / nested_object / array); `cascade_paths` records,
+        // per source table, the exact source columns the embed reads. All three feed the
+        // decision below: `parents` (which drives flush-time entity propagation) drops a
+        // scalar embed reading only the child's own columns, while `children` (which drives
+        // topological refresh ordering) keeps every edge.
+        let query = "SELECT entity, fk_columns, dependency_types, cascade_paths FROM pg_tview_meta";
 
         let mut parents: HashMap<String, Vec<String>> = HashMap::new();
         let mut children: HashMap<String, Vec<String>> = HashMap::new();
@@ -59,25 +78,68 @@ impl EntityDepGraph {
                             query: query.to_string(),
                             error: format!("Failed to get fk_columns: {e}"),
                         })?;
+                // `dependency_types[i]` is positionally aligned with `fk_columns[i]`
+                // (same contract as `TviewMeta::parse_dependencies`).
+                let dependency_types: Vec<String> = row["dependency_types"]
+                    .value()
+                    .map_err(|e| crate::TViewError::SpiError {
+                        query: query.to_string(),
+                        error: format!("Failed to get dependency_types: {e}"),
+                    })?
+                    .unwrap_or_default();
+                let cascade_paths_raw: Vec<String> = row["cascade_paths"]
+                    .value()
+                    .map_err(|e| crate::TViewError::SpiError {
+                        query: query.to_string(),
+                        error: format!("Failed to get cascade_paths: {e}"),
+                    })?
+                    .unwrap_or_default();
+
+                // Deserialize with the same typed struct the trigger path consumes. A
+                // path we cannot parse simply doesn't contribute to `reads_by_fk`, which
+                // keeps the corresponding edge — the safe default. (The runtime cascade
+                // path has its own deserialization, so a real parse failure surfaces
+                // there, not silently here.)
+                let cascade_paths: Vec<CascadePath> = cascade_paths_raw
+                    .iter()
+                    .filter_map(|s| serde_json::from_str(s).ok())
+                    .collect();
+                let reads_by_fk = source_columns_by_fk(&cascade_paths);
 
                 all_entities.insert(entity.clone());
 
                 if let Some(fk_cols) = fk_columns {
-                    for fk_col in fk_cols {
+                    for (i, fk_col) in fk_cols.iter().enumerate() {
                         // FK column format: "fk_<entity>"
                         // Example: "fk_user" -> "user"
                         if let Some(parent_entity) = fk_col.strip_prefix("fk_") {
-                            // Register parent relationship
-                            parents
-                                .entry(parent_entity.to_string())
-                                .or_default()
-                                .push(entity.clone());
-
-                            // Register child relationship
+                            // Topological ordering must respect every dependency, so
+                            // `children` records the edge unconditionally.
                             children
                                 .entry(entity.clone())
                                 .or_default()
                                 .push(parent_entity.to_string());
+
+                            // Skip flush-time entity propagation for a scalar embed that
+                            // reads ONLY the child's own (non-FK) columns: it is already
+                            // covered by the column-aware `tb_<child>` cascade path, so
+                            // propagating here is redundant and over-refreshes. Keep the
+                            // edge for nested_object/array embeds, for scalar embeds that
+                            // follow a child FK (a deeper relationship no `tb_<child>` path
+                            // covers), and whenever the classification or columns are
+                            // unknown — the safe default.
+                            let is_scalar =
+                                dependency_types.get(i).is_some_and(|t| t.as_str() == "scalar");
+                            let reads_only_own_columns =
+                                reads_by_fk.get(fk_col).is_some_and(|cols| {
+                                    !cols.is_empty() && !cols.iter().any(|c| c.starts_with("fk_"))
+                                });
+                            if !(is_scalar && reads_only_own_columns) {
+                                parents
+                                    .entry(parent_entity.to_string())
+                                    .or_default()
+                                    .push(entity.clone());
+                            }
                         }
                     }
                 }
@@ -118,6 +180,28 @@ impl EntityDepGraph {
 
         sorted_keys
     }
+}
+
+/// Map each embedded relationship's FK column to the base-table source columns its
+/// embed reads, taken from this entity's cascade paths.
+///
+/// A cascade path refreshes this entity when a source table changes; its final step
+/// into this entity's own base table matches `lookup_col == fk_<child>` — the last
+/// hop's `lookup_col`, or `initial_col` when the path has no hops. That FK column keys
+/// the path's `source_columns`. Paths landing on the same FK are unioned, so a later
+/// empty (multi-hop) path never masks a direct path's FK reference.
+fn source_columns_by_fk(paths: &[CascadePath]) -> HashMap<String, Vec<String>> {
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    for path in paths {
+        let fk = path
+            .hops
+            .last()
+            .map_or(path.initial_col.as_str(), |h| h.lookup_col.as_str());
+        out.entry(fk.to_string())
+            .or_default()
+            .extend(path.source_columns.iter().cloned());
+    }
+    out
 }
 
 /// Topological sort using Kahn's algorithm
@@ -249,5 +333,118 @@ mod tests {
         assert!(company_idx < user_idx);
         assert!(user_idx < post_idx);
         assert!(post_idx < feed_idx);
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod pg_tests {
+    use super::*;
+    use pgrx::prelude::Spi;
+
+    /// Column-aware multi-hop propagation graph shape:
+    /// - `nested_object` embed (post embeds `v_user.data`) → propagation parent (user → post).
+    /// - `scalar` embed reading only the child's own columns (shallow embeds only
+    ///   `post.title`) → NOT a propagation parent; the `tb_post` cascade path covers it.
+    /// - `scalar` embed following a child FK (deep embeds `post.author`, reading the
+    ///   post's `fk_author`) → still a propagation parent; no `tb_post` path covers the
+    ///   two-level author change.
+    ///
+    /// All three edges stay in `children`, so topological ordering is unchanged.
+    #[pg_test]
+    fn test_scalar_embed_propagation_is_fk_aware() {
+        Spi::run("CREATE TABLE tb_user (pk_user BIGSERIAL PRIMARY KEY, name TEXT)").unwrap();
+        Spi::run(
+            "CREATE TABLE tb_post (pk_post BIGSERIAL PRIMARY KEY, \
+             fk_author BIGINT REFERENCES tb_user(pk_user), title TEXT)",
+        )
+        .unwrap();
+        // shallow: embeds only the post's own title (scalar, no child FK read)
+        Spi::run(
+            "CREATE TABLE tb_shallow (pk_shallow BIGSERIAL PRIMARY KEY, \
+             fk_post BIGINT REFERENCES tb_post(pk_post), body TEXT)",
+        )
+        .unwrap();
+        // deep: embeds the post AND the post's author (scalar, reads post.fk_author)
+        Spi::run(
+            "CREATE TABLE tb_deep (pk_deep BIGSERIAL PRIMARY KEY, \
+             fk_post BIGINT REFERENCES tb_post(pk_post), body TEXT)",
+        )
+        .unwrap();
+
+        Spi::run(
+            "SELECT pg_tviews_create('user', $$
+                SELECT pk_user, jsonb_build_object('name', name) AS data FROM tb_user
+            $$)",
+        )
+        .unwrap();
+        // post embeds the whole computed user document → nested_object dependency
+        Spi::run(
+            "SELECT pg_tviews_create('post', $$
+                SELECT pk_post, fk_author,
+                       jsonb_build_object('title', title, 'author', v_user.data) AS data
+                FROM tb_post LEFT JOIN v_user ON v_user.pk_user = tb_post.fk_author
+            $$)",
+        )
+        .unwrap();
+        // shallow: scalar embed of only the post's title → base path covers it
+        Spi::run(
+            "SELECT pg_tviews_create('shallow', $$
+                SELECT pk_shallow, fk_post,
+                       jsonb_build_object('body', body, 'post',
+                           jsonb_build_object('title', tb_post.title)) AS data
+                FROM tb_shallow JOIN tb_post ON tb_post.pk_post = tb_shallow.fk_post
+            $$)",
+        )
+        .unwrap();
+        // deep: scalar embed that follows post.fk_author to embed post.author
+        Spi::run(
+            "SELECT pg_tviews_create('deep', $$
+                SELECT pk_deep, fk_post,
+                       jsonb_build_object('body', body, 'post',
+                           jsonb_build_object('title', p.title,
+                               'author', jsonb_build_object('name', pu.name))) AS data
+                FROM tb_deep d
+                JOIN tb_post p  ON p.pk_post = d.fk_post
+                JOIN tb_user pu ON pu.pk_user = p.fk_author
+            $$)",
+        )
+        .unwrap();
+
+        let graph = EntityDepGraph::load().unwrap();
+        let post_parents = graph.parents.get("post").cloned().unwrap_or_default();
+        let user_parents = graph.parents.get("user").cloned().unwrap_or_default();
+
+        // nested_object: user -> post propagates
+        assert!(
+            user_parents.contains(&"post".to_string()),
+            "nested_object embed (post←user) must propagate; got {user_parents:?}"
+        );
+        // scalar own-columns: post -> shallow must NOT propagate
+        assert!(
+            !post_parents.contains(&"shallow".to_string()),
+            "scalar own-column embed (shallow←post) must be excluded; got {post_parents:?}"
+        );
+        // scalar following a child FK: post -> deep MUST propagate
+        assert!(
+            post_parents.contains(&"deep".to_string()),
+            "scalar embed reading post.fk_author (deep←post) must propagate; got {post_parents:?}"
+        );
+
+        // Every edge stays in `children` so topo ordering is preserved.
+        for child in ["shallow", "deep"] {
+            assert!(
+                graph
+                    .children
+                    .get(child)
+                    .is_some_and(|c| c.contains(&"post".to_string())),
+                "topo children must retain edge ({child}→post)"
+            );
+            assert!(
+                graph.topo_order.iter().position(|e| e == "post")
+                    < graph.topo_order.iter().position(|e| e == child),
+                "topo order must refresh post before {child}"
+            );
+        }
     }
 }

--- a/test/sql/regress_issue_multihop_propagation_prune.sql
+++ b/test/sql/regress_issue_multihop_propagation_prune.sql
@@ -1,0 +1,172 @@
+-- Regression test: multi-hop column-aware propagation prune.
+--
+-- Flush-time ENTITY propagation (src/propagate.rs, driven by EntityDepGraph.parents)
+-- fired for EVERY change to a child entity, unconditionally recomputing every parent
+-- that embeds it. For a scalar embed reading only the child's own columns (a comment
+-- embedding the post's {title}) that recompute is pure waste: the column can change
+-- only via the child's base table, which is already covered by the column-aware
+-- tb_<child> cascade path. Worse, it fired even when the child was recomputed for an
+-- UNRELATED deeper embed — a post refreshed because its author's bio changed dragged
+-- every comment on that post through a data-preserving recompute.
+--
+-- On a three-level chain user -> post -> comment this proves:
+--   * updateUser(bio) refreshes tv_post (which embeds the whole author document) but
+--     does NOT process the comment entity at all (propagation edge pruned) and leaves
+--     tv_comment BYTE-IDENTICAL — the comment embeds only post.title, so there is no
+--     staleness;
+--   * changing post.title DOES refresh tv_comment (via the tb_post cascade path that
+--     covers the pruned edge) — the prune introduces no staleness when the embedded
+--     column actually changes;
+--   * a newly inserted comment embeds the current post title;
+--   * the fast path stays byte-identical to a forced full recompute.
+--
+-- The complementary graph-shape property — nested_object/array embeds, and scalar
+-- embeds that follow a child FK, are KEPT — is covered by the #[pg_test]
+-- test_scalar_embed_propagation_is_fk_aware in src/queue/graph.rs.
+--
+--   psql -v ON_ERROR_STOP=1 -f test/sql/regress_issue_multihop_propagation_prune.sql
+
+\set ON_ERROR_STOP on
+SET client_min_messages TO WARNING;
+
+DROP EXTENSION IF EXISTS pg_tviews CASCADE;
+DROP EXTENSION IF EXISTS jsonb_delta CASCADE;
+CREATE EXTENSION jsonb_delta;
+CREATE EXTENSION pg_tviews;
+
+-- Per-entity REFRESH events land in pg_tview_audit_log; used below to prove the
+-- comment entity is (or is not) processed by a given mutation.
+SET pg_tviews.audit_enabled = on;
+
+DROP TABLE IF EXISTS tv_comment CASCADE; DROP VIEW IF EXISTS v_comment CASCADE;
+DROP TABLE IF EXISTS tv_post CASCADE;    DROP VIEW IF EXISTS v_post CASCADE;
+DROP TABLE IF EXISTS tv_user CASCADE;    DROP VIEW IF EXISTS v_user CASCADE;
+DROP TABLE IF EXISTS tb_comment CASCADE;
+DROP TABLE IF EXISTS tb_post CASCADE;
+DROP TABLE IF EXISTS tb_user CASCADE;
+
+CREATE TABLE tb_user (
+    pk_user INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    username TEXT, bio TEXT
+);
+-- The FK is named fk_user (matching the referenced entity): flush-time entity
+-- propagation keys parents by fk_<entity>, so this is what makes user -> post a
+-- propagation edge at all.
+CREATE TABLE tb_post (
+    pk_post INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    fk_user INTEGER REFERENCES tb_user(pk_user), title TEXT
+);
+CREATE TABLE tb_comment (
+    pk_comment INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+    fk_post INTEGER REFERENCES tb_post(pk_post), body TEXT
+);
+
+INSERT INTO tb_user (username, bio) VALUES ('alice', 'a-bio');
+INSERT INTO tb_post (fk_user, title) VALUES (1, 'P1');
+INSERT INTO tb_comment (fk_post, body)
+    VALUES (1, 'C1'), (1, 'C2'), (1, 'C3'), (1, 'C4'), (1, 'C5');
+
+-- tv_user: embeds bio (its own base column).
+SELECT pg_tviews_create('tv_user', $TVIEW$
+    SELECT pk_user, id, jsonb_build_object('username', username, 'bio', bio) AS data
+    FROM tb_user
+$TVIEW$);
+
+-- tv_post: embeds the whole COMPUTED user document (nested_object dependency) → the
+-- user -> post edge is a genuine propagation edge and must be kept.
+SELECT pg_tviews_create('tv_post', $TVIEW$
+    SELECT p.pk_post, p.id, p.fk_user,
+           jsonb_build_object('title', p.title, 'author', v_user.data) AS data
+    FROM tb_post p LEFT JOIN v_user ON v_user.pk_user = p.fk_user
+$TVIEW$);
+
+-- tv_comment: scalar embed of ONLY the post's own title, read from tb_post columns
+-- via a direct JOIN → the post -> comment propagation edge is redundant with the
+-- column-aware tb_post cascade path and is pruned.
+SELECT pg_tviews_create('tv_comment', $TVIEW$
+    SELECT c.pk_comment, c.id, c.fk_post,
+           jsonb_build_object('body', c.body,
+               'post', jsonb_build_object('title', p.title)) AS data
+    FROM tb_comment c JOIN tb_post p ON p.pk_post = c.fk_post
+$TVIEW$);
+
+CREATE FUNCTION _refreshed(ent text) RETURNS bigint LANGUAGE sql AS
+  $$ SELECT count(*) FROM pg_tview_audit_log WHERE entity = ent AND operation = 'REFRESH' $$;
+
+-- Sanity: comments embed the initial post title.
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM tv_comment WHERE data->'post'->>'title' = 'P1') <> 5 THEN
+    RAISE EXCEPTION 'setup FAIL: comments do not embed the initial post title';
+  END IF;
+END $$;
+
+-- ── Case 1: updateUser(bio) refreshes the post but PRUNES the comments ────────────
+-- bio is embedded by tv_post (nested author document) but NOT by tv_comment. The
+-- comment entity must not be processed at all, and its rows must stay byte-identical.
+DO $$
+DECLARE c0 bigint; before jsonb; after jsonb;
+BEGIN
+  SELECT jsonb_agg(data ORDER BY pk_comment) INTO before FROM tv_comment;
+  c0 := _refreshed('comment');
+
+  UPDATE tb_user SET bio = 'a-bio-CHANGED' WHERE pk_user = 1;
+
+  -- Prune: the comment entity was never processed (no REFRESH audit event).
+  IF _refreshed('comment') <> c0 THEN
+    RAISE EXCEPTION 'prune FAIL: bio update processed the comment entity % time(s) (expected 0)',
+      _refreshed('comment') - c0;
+  END IF;
+  -- No staleness: comment documents are byte-identical (they never embedded bio).
+  SELECT jsonb_agg(data ORDER BY pk_comment) INTO after FROM tv_comment;
+  IF before IS DISTINCT FROM after THEN
+    RAISE EXCEPTION 'prune FAIL: tv_comment changed on an unrelated bio update';
+  END IF;
+  -- The kept nested edge still works: tv_post reflects the new bio.
+  IF (SELECT data->'author'->>'bio' FROM tv_post WHERE pk_post = 1) <> 'a-bio-CHANGED' THEN
+    RAISE EXCEPTION 'propagation FAIL: tv_post.author.bio not refreshed (user->post edge lost)';
+  END IF;
+END $$;
+
+-- ── Case 2: changing post.title refreshes the comments via the tb_post cascade path ─
+-- The pruned propagation edge must be fully covered by the column-aware base path.
+DO $$
+DECLARE c0 bigint;
+BEGIN
+  c0 := _refreshed('comment');
+  UPDATE tb_post SET title = 'P1-RENAMED' WHERE pk_post = 1;
+
+  IF _refreshed('comment') = c0 THEN
+    RAISE EXCEPTION 'coverage FAIL: post.title change did not refresh any comment';
+  END IF;
+  IF (SELECT count(*) FROM tv_comment WHERE data->'post'->>'title' = 'P1-RENAMED') <> 5 THEN
+    RAISE EXCEPTION 'coverage FAIL: only % of 5 comments reflect the new post title',
+      (SELECT count(*) FROM tv_comment WHERE data->'post'->>'title' = 'P1-RENAMED');
+  END IF;
+END $$;
+
+-- ── Case 3: a newly inserted comment embeds the current post title ────────────────
+DO $$
+BEGIN
+  INSERT INTO tb_comment (fk_post, body) VALUES (1, 'C6');
+  IF (SELECT data->'post'->>'title' FROM tv_comment WHERE data->>'body' = 'C6') <> 'P1-RENAMED' THEN
+    RAISE EXCEPTION 'insert FAIL: new comment did not embed the current post title';
+  END IF;
+END $$;
+
+-- ── Case 4: byte-identity — fast path == forced full recompute ────────────────────
+DO $$
+DECLARE fast jsonb; rec jsonb;
+BEGIN
+  SELECT jsonb_agg(data ORDER BY pk_comment) INTO fast FROM tv_comment;
+  PERFORM pg_tviews_refresh('comment');
+  SELECT jsonb_agg(data ORDER BY pk_comment) INTO rec FROM tv_comment;
+  IF fast IS DISTINCT FROM rec THEN
+    RAISE EXCEPTION 'byte-identity FAIL: tv_comment not identical to a forced recompute';
+  END IF;
+END $$;
+
+SELECT 'multi-hop propagation prune: PASS' AS result;


### PR DESCRIPTION
## Summary

Flush-time **entity propagation** (`EntityDepGraph.parents`, consumed by `src/propagate.rs`) fired for *every* change to a child entity, unconditionally recomputing every parent that embeds it. For a scalar embed reading only the child's own columns — a comment embedding the post's `{title}` — that recompute is redundant with the column-aware `tb_<child>` cascade path shipped in beta.15 (#64). Worse, it fired even when the child was recomputed for an **unrelated deeper embed**: a post recomputed because its author's bio changed dragged every comment on that post through a data-preserving recompute.

This ports velocitybench's multi-hop finding, reimplemented for upstream:

- `EntityDepGraph::load` drops a `parents` edge for a **scalar embed that reads only the child's own non-FK columns** — already covered by the column-aware `tb_<child>` cascade path. `children` (topological ordering) keeps every edge, so refresh order is unchanged.
- **Safety gate:** the edge is dropped *only* when a covering cascade path provably exists (non-empty, all-non-FK `source_columns`, derived from column-level `pg_depend`). Any ambiguity — `nested_object`/`array` embeds, scalar embeds following a child FK, unknown/empty columns — keeps the edge. This is the safe default.
- Uses **typed `CascadePath` deserialization** (the same struct the trigger path consumes), not ad-hoc JSON parsing.

## Measured effect (velocitybench lean schema)
- `updateUser(bio)`: 110 → ~11 recomputes (tv_user + ~10 tv_post; comments skipped)
- `updateUser(username)`: 110 → ~61 (adds the user's own ~50 comments via the cascade path — correct)

## Correctness note
Removing the unconditional edge removes a redundancy that masked any column-tracking gap in the cascade path. Correctness now depends fully on `source_columns` (pg_depend) completeness — the **same dependency beta.15's column-aware cascade already took**, validated by `regress_issue_column_aware_qualifier`.

## Tests
- `test/sql/regress_issue_multihop_propagation_prune.sql` — end-to-end on a `user → post → comment` chain, **verified RED→GREEN** (without the change it fails "bio update processed the comment entity 1 time(s)"). Asserts prune + byte-identity (no staleness) on an unrelated bio change; cascade-path coverage on a `post.title` change.
- Graph-shape `#[pg_test]` in `graph.rs` (nested kept / scalar-own pruned / scalar-following-FK kept).

## Verification
- ✅ 26/26 regression + 35/35 integration on PG18 (was 25/25 + 35/35)
- ✅ Clippy clean (`--all-targets --no-default-features --features pg18 -- -D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)