### PR TITLE
fix(release): grant attestations:write for build provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
 
 permissions:
   contents: write
-  id-token: write  # Required for Sigstore
+  id-token: write       # Required for Sigstore keyless signing
+  attestations: write   # Required for actions/attest-build-provenance to persist the attestation
 
 jobs:
   build-and-sign:


### PR DESCRIPTION
## Summary

The Release job's **Generate provenance** step (`actions/attest-build-provenance@v1`) failed on **v0.1.0-beta.16** with:

```
Failed to persist attestation: Resource not accessible by integration
```

`release.yml`'s `permissions:` block grants `contents: write` and `id-token: write` but **not `attestations: write`**, which the action requires to persist the attestation. This is the last blocker before the `Create release` step that attaches the signed source tarball.

## Context

beta.16 validated the previous signing fix (#65): **Sign with Sigstore (keyless)** passed for the first time (beta.15 died there), exposing this next latent permission gap — the recurring "each fix uncovers the next step" pattern in this pipeline. Everything else in beta.16 is green (crates.io publish, SBOM, SLSA provenance, GitHub release).

## Change

- `.github/workflows/release.yml`: add `attestations: write` to the permissions block.

Effective on the next tag (a running workflow reads its definition from the tag's commit, so beta.16 can't be retroactively fixed without re-tagging). Validated by cutting the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)